### PR TITLE
Core: IsDoubleWidth() function to simplify handling of double width Unicode characters

### DIFF
--- a/uppsrc/Core/CharSet.cpp
+++ b/uppsrc/Core/CharSet.cpp
@@ -2296,4 +2296,25 @@ String ToLowerAscii(const String& s, byte charset)
 	return r;
 }
 
+bool IsDoubleWidth(int c)
+{
+	// This function is taken from Markus Kuhn's wcwidth implementation.
+	// For license and implementation details, see:
+	// https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+	
+	return  c >= 0x1100
+		&& (c <= 0x115F										// Hangul Jamo init. consonants
+			||  c == 0x2329
+			||  c == 0x232A
+			|| (c >= 0x2E80 && c <= 0xA4CF && c != 0x303F)	// CJK ... Yi
+			|| (c >= 0xAC00 && c <= 0xD7A3)					// Hangul syllables
+			|| (c >= 0xF900 && c <= 0xFAFF)					// CJK compatibility ideographs
+			|| (c >= 0xFE10 && c <= 0xFE19)					// Vertical forms
+			|| (c >= 0xFE30 && c <= 0xFE6F)					// CJK compatibility forms
+			|| (c >= 0xFF00 && c <= 0xFF60)					// Fullwidth forms
+			|| (c >= 0xFFE0 && c <= 0xFFE6)
+			|| (c >= 0x20000 && c <= 0x2FFFD)
+			|| (c >= 0x30000 && c <= 0x3FFFD)
+			);
+}
 }

--- a/uppsrc/Core/CharSet.h
+++ b/uppsrc/Core/CharSet.h
@@ -192,6 +192,8 @@ inline bool IsXDigit(int c)        { return IsDigit(c) || c >= 'A' && c <= 'F' |
 
 inline bool IsCJKIdeograph(int c)  { return c >= 0x2e80 && c <= 0xdfaf || c >= 0xf900 && c <= 0xfaff; }
 
+bool IsDoubleWidth(int c);
+
 word UnicodeCombine(word chr, word combine);
 
 String Utf8ToAscii(const String& src);

--- a/uppsrc/Core/src.tpp/CharSet_en-us.tpp
+++ b/uppsrc/Core/src.tpp/CharSet_en-us.tpp
@@ -398,6 +398,11 @@ character.&]
 [s2;%% Returns true if [%-*@3 c].is in UNICODE code`-point for CJK 
 ideogram.&]
 [s3;%% &]
+[s4; &]
+[s5;:Upp`:`:IsDoubleWidth`(int`): [@(0.0.255) bool]_[* IsDoubleWidth]([@(0.0.255) int]_[*@3 c
+])&]
+[s2;%% Returns true if [%-*@3 c] is a double`-width UNICODE character.&]
+[s3;%% &]
 [s4;%% &]
 [s5;:UnicodeCombine`(word`,word`): [_^word^ word]_[* UnicodeCombine]([_^word^ word]_[*@3 chr],
  [_^word^ word]_[*@3 combine])&]


### PR DESCRIPTION
I propose adding IsDoubleWidth() function to Upp/Core.
It simplifies Eastern-Asian/CJK character handling, and seems to cover more than IsCJKIdeograph().
This code is a "rip-off" from [Markus Kuhns wcwidth() implementation.](https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c). It is widely used, and doesn't seem to have a problematic license.
