### PR TITLE
VecLine::Clip infinite recursion fix

### DIFF
--- a/uppsrc/Geom/geometry.h
+++ b/uppsrc/Geom/geometry.h
@@ -286,7 +286,7 @@ public:
 
 	Pointf        Intersect(VecLine another) const;
 	VecLine&      SetClip(const Rectf& rect);
-	VecLine       Clip(const Rectf& rect) const            { return VecLine(*this).Clip(rect); }
+	VecLine       Clip(const Rectf& rect) const            { return VecLine(*this).SetClip(rect); }
 
 	double        Distance(Pointf point, double *arg = NULL) const;
 


### PR DESCRIPTION
It looks like, from looking at the function signature `Clip(const Rectf& rect) const` that the intent here is to keep the operated-on `VecLine` immutable and return a _copy_ clipped by `rect`.

This change effects that logic while breaking the infinite recursion.