### PR TITLE
SysInfo: fix MouseKey.cpp compile w/ NO_XTEST on non-Win32 platforms

### DIFF
--- a/bazaar/SysInfo/MouseKey.cpp
+++ b/bazaar/SysInfo/MouseKey.cpp
@@ -531,7 +531,6 @@ void Keyb_SendKeys(String text, long finalDelay, long delayBetweenKeys)
 	Sleep(finalDelay);
 }
 
-}
-
 #endif
+}
 


### PR DESCRIPTION
The `#if defined(PLATFORM_WIN32) || !defined(flagNO_XTEST)` directive
was incorrectly `#endif`'d outside the `namespace Upp` block it was opened
in, leading to a syntactically invalid file with an unterminated
namespace block when this `#ifdef` is false.