### PR TITLE
Delete upphub.root

### DIFF
--- a/upphub.root
+++ b/upphub.root
@@ -1,5 +1,0 @@
-{
-  "links": [
-    "https://raw.githubusercontent.com/ultimatepp/UppHub/main/README.md"
-  ]
-}


### PR DESCRIPTION
Since we have separate repo for UppHub we do not need upphub.root anymore in this repository.