### PR TITLE
CtrlLib: Gui14 tutorial example now sets minimal window size in order…

### DIFF
--- a/tutorial/Gui14/main.cpp
+++ b/tutorial/Gui14/main.cpp
@@ -6,7 +6,7 @@ struct MyAppWindow : TopWindow {
 	Button lt, rt, lb, rb, lv, ht, hv, cb, rc;
 
 	MyAppWindow() {
-		Title("My application with button").Sizeable();
+		Title("My application with button").Sizeable().SetMinSize(Zsz(640, 480));
 		*this
 			<< lt.SetLabel("left-top").LeftPos(10, 200).TopPos(10, 40)
 			<< rt.SetLabel("right-top").RightPos(10, 200).TopPos(10, 40)

--- a/uppsrc/CtrlLib/srcdoc.tpp/Tutorial_en-us.tpp
+++ b/uppsrc/CtrlLib/srcdoc.tpp/Tutorial_en-us.tpp
@@ -775,7 +775,8 @@ logical coordinate the specifies the center position.&]
 [s7; -|Button lt, rt, lb, rb, lv, ht, hv, cb, rc;&]
 [s7; &]
 [s7; -|MyAppWindow() `{&]
-[s7; -|-|Title(`"My application with button`").Sizeable();&]
+[s7; -|-|Title(`"My application with button`").Sizeable().SetMinSize(Zsz(640, 
+480));&]
 [s7; -|-|`*this&]
 [s7; [* -|-|-|<< lt.SetLabel(`"left`-top`").LeftPos(10, 200).TopPos(10, 
 40)]&]


### PR DESCRIPTION
In order to correctly render Gui14 example content the window should posses minimal size. The fix improve the example by adding SetMinSize.