### PR TITLE
File Sel's file list should use no round size mode

### DIFF
--- a/uppsrc/CtrlLib/FileSel.cpp
+++ b/uppsrc/CtrlLib/FileSel.cpp
@@ -2390,6 +2390,8 @@ FileSel::FileSel()
 	places.NoHeader().NoGrid();
 	places.WhenLeftClick = THISBACK(GoToPlace);
 	places.NoWantFocus();
+	
+	list.NoRoundSize();
 
 #ifdef PLATFORM_WIN32
 	int icx = GetFileIcon(GetHomeDirectory(), true, false, false).GetSize().cx;


### PR DESCRIPTION
Right now, the FileSel scaling behaves in a strange way. To overcome this issue NoRoundSize mode for file list should be enable.