### PR TITLE
Use dark window titlebar on Windows 10+ with dark themes

### DIFF
--- a/uppsrc/CtrlCore/Win32Wnd.cpp
+++ b/uppsrc/CtrlCore/Win32Wnd.cpp
@@ -487,6 +487,16 @@ void Ctrl::Create(HWND parent, DWORD style, DWORD exstyle, bool savebits, int sh
 
 	ASSERT(top->hwnd);
 	::MoveWindow(top->hwnd, r.left, r.top, r.Width(), r.Height(), false); // To avoid "black corners" artifact effect
+
+	HRESULT (WINAPI *DwmSetWindowAttribute)(HWND hwnd, DWORD dwAttribute, LPCVOID pvAttribute, DWORD cbAttribute);
+	DllFn(DwmSetWindowAttribute, "dwmapi.dll", "DwmSetWindowAttribute");
+	if (DwmSetWindowAttribute) {
+		BOOL useDarkTheme = IsDarkTheme(); 
+		DwmSetWindowAttribute(
+			top->hwnd, 20, /* 20 is DWMWINDOWATTRIBUTE::DWMWA_USE_IMMERSIVE_DARK_MODE */
+			&useDarkTheme, sizeof(useDarkTheme));
+	}
+
 	::ShowWindow(top->hwnd, visible ? show : SW_HIDE);
 //	::UpdateWindow(hwnd);
 	StateH(OPEN);


### PR DESCRIPTION
This PR makes titlebar on Windows 10+ to match application dark mode.

Here's "Button" example compiled before and after applying the patch:
![](https://user-images.githubusercontent.com/2903496/174449928-732c9956-1d0d-4cab-9bdf-8cff6f6f0844.png)

Compiled apps will also work on older systems that doesn't support attribute or even DWM itself.