### PR TITLE
CtrlLib: Fixed unreadable calendar header

### DIFF
--- a/uppsrc/CtrlLib/CtrlLib.usc
+++ b/uppsrc/CtrlLib/CtrlLib.usc
@@ -1379,7 +1379,7 @@ ctrl DropDate {
 		n = r.bottom - r.top;
 		DrawDropButton(w, RectC(r.right - n, r.top, n, n));
 		w.DrawText(3, (GetSize().cy - GetTextSize("", Arial(10)).cy) / 2,
-			(.SetEditable ? "" : "R/O ") + (.NotNull ? "!" : "") + "01/05/2007", Arial(10), :SMagenta);
+			(.SetEditable ? "" : "R/O ") + (.NotNull ? "!" : "") + "25/07/2022", Arial(10), :SMagenta);
 	}
 }
 
@@ -1407,7 +1407,7 @@ ctrl DropTime {
 		n = r.bottom - r.top;
 		DrawDropButton(w, RectC(r.right - n, r.top, n, n));
 		w.DrawText(3, (GetSize().cy - GetTextSize("", Arial(10)).cy) / 2,
-			(.SetEditable ? "" : "R/O ") + (.NotNull ? "!" : "") + "01/05/2007 10:34:58", Arial(10), :SMagenta);
+			(.SetEditable ? "" : "R/O ") + (.NotNull ? "!" : "") + "25/07/2022 10:34:58", Arial(10), :SMagenta);
 	}
 }
 
@@ -1587,7 +1587,7 @@ ctrl Calendar {
 			}
 		}
 
-		today = "Today: 01/19/2007";
+		today = "Today: 25/07/2022";
 		ts = GetTextSize(today, StdFont().Bold());
 		w.DrawText((r.right - ts.cx) / 2, r.bottom - 3 - ts.cy, today, f.Bold(), :SBlue);
 
@@ -1601,7 +1601,7 @@ ctrl Calendar {
 		right = r.right;
 		r.left -= 15 + 40;
 		r.right -= 15 + 40;
-		PaintCenterText(w, (r.left + right) / 2, (r.top + r.bottom) / 2, "2007", f.Bold(), :SWhite);
+		PaintCenterText(w, (r.left + right) / 2, (r.top + r.bottom) / 2, "2022", f.Bold(), :SWhite);
 
 		DrawCtrlFrame(w, ro, .SetFrame);
 	}

--- a/uppsrc/CtrlLib/DateTimeCtrl.cpp
+++ b/uppsrc/CtrlLib/DateTimeCtrl.cpp
@@ -83,7 +83,7 @@ void Calendar::Reset()
 Calendar& Calendar::SetStyle(const Style& s)
 {
 	style = &s;
-	nbg = CtrlImg::Bg();
+	nbg = Colorize(IsDarkTheme() ? DarkTheme(CtrlImg::Bg()) : CtrlImg::Bg(), s.header);
 	Refresh();
 	return *this;
 }
@@ -800,7 +800,7 @@ LineCtrl::LineCtrl()
 Clock& Clock::SetStyle(const Style& s)
 {
 	style = &s;
-	nbg = CtrlImg::Bg();
+	nbg = Colorize(IsDarkTheme() ? DarkTheme(CtrlImg::Bg()) : CtrlImg::Bg(), s.header);
 	Refresh();
 	return *this;
 }


### PR DESCRIPTION
This PR supposed to fixed problem raised on our forum (https://www.ultimatepp.org/forums/index.php?t=msg&goto=58699&#msg_58699) with unreadable Calendar header. The solution to be universal is basing on system selection color. My fix also adjust dark theme.

Normal:
![CalendarFix](https://user-images.githubusercontent.com/6963025/180867199-21a98f09-b938-4669-8d63-d2e3b60df1dd.png)

Dark:
![CalendarFixDark](https://user-images.githubusercontent.com/6963025/180867221-f5286d45-f7c1-4a7d-8687-020220944a94.png)



