### PR TITLE
Custom Dpi for PdfDraw

### DIFF
--- a/uppsrc/PdfDraw/PdfDraw.cpp
+++ b/uppsrc/PdfDraw/PdfDraw.cpp
@@ -19,13 +19,14 @@ Size PdfDraw::GetPageSize() const
 	return pgsz;
 }
 
-void PdfDraw::Init(int pagecx, int pagecy, int _margin, bool _pdfa)
+void PdfDraw::Init(int pagecx, int pagecy,int _dpi, int _margin, bool _pdfa)
 {
 	Clear();
 	margin = _margin;
 	pdfa = _pdfa;
 	pgsz.cx = pagecx;
 	pgsz.cy = pagecy;
+	dpi = _dpi;
 	pgsz += margin;
 	current_offset = Point(0, 0);
 	StartPage();
@@ -517,6 +518,7 @@ static Image sJPEGDummy()
 void DrawJPEG(Draw& w, int x, int y, int cx, int cy, const String& jpeg_data)
 {
 	w.Escape("data:" + jpeg_data);
+	
 	w.DrawImage(x, y, cx, cy, sJPEGDummy());
 }
 
@@ -528,6 +530,7 @@ int PdfDraw::PdfImage(const Image& img, const Rect& src)
 		q = images.GetCount();
 		images.Add(key, img);
 	}
+	
 	return q;
 }
 
@@ -541,7 +544,6 @@ void PdfDraw::DrawImageOp(int x, int y, int cx, int cy, const Image& _img, const
 	
 	if(img.GetSerialId() == sJPEGDummy().GetSerialId())
 		jpeg.Add(data);
-	
 	page << "q "
 	     << Pt(cx) << " 0 0 " << Pt(cy) << ' '
 	     << Pt(x) << ' ' << Pt(pgsz.cy - y - cy)

--- a/uppsrc/PdfDraw/PdfDraw.h
+++ b/uppsrc/PdfDraw/PdfDraw.h
@@ -301,6 +301,7 @@ private:
 	StringBuffer out;
 	StringBuffer page;
 	Size        pgsz;
+	int			dpi;
 	Color       rgcolor;
 	Color       RGcolor;
 	int         fontid;
@@ -314,7 +315,7 @@ private:
 	Vector<Point> offset_stack;
 	Point       current_offset;
 
-	double Pt(double dot)               { return 0.12 * dot; }
+	double Pt(double dot)               { return 72 * dot / dpi ; }
 	String Ptf(double dot)              { return FormatF(Pt(dot), 5); }
 
 	int    Pos()                        { return offset.GetCount() + 1; }
@@ -338,7 +339,7 @@ private:
 
 	OutlineInfo GetOutlineInfo(Font fnt);
 
-	void Init(int pagecx, int pagecy, int margin, bool pdfa);
+	void Init(int pagecx, int pagecy, int dpi, int margin, bool pdfa);
 
 	struct RGlyph : Moveable<RGlyph> {
 		String data;
@@ -364,8 +365,8 @@ public:
 	void   Clear();
 	bool   IsEmpty() const                                   { return empty; }
 	
-	PdfDraw(int pagecx, int pagecy, bool pdfa = false)       { Init(pagecx, pagecy, 0, pdfa); }
-	PdfDraw(Size pgsz = Size(5100, 6600), bool pdfa = false) { Init(pgsz.cx, pgsz.cy, 0, pdfa); }
+	PdfDraw(int pagecx, int pagecy,int dpi = 600 , bool pdfa = false)       { Init(pagecx, pagecy, dpi, 0, pdfa); }
+	PdfDraw(Size pgsz = Size(5100, 6600),int dpi = 600, bool pdfa = false) { Init(pgsz.cx, pgsz.cy, dpi, 0, pdfa); }
 };
 
 void DrawJPEG(Draw& w, int x, int y, int cx, int cy, const String& jpeg_data);


### PR DESCRIPTION
issue:
DrawImage of an image with different DPI than 600 causes wrong pdf size output.