### PR TITLE
Fixed issue with wrong text color on selected menu item (Win11)

### DIFF
--- a/uppsrc/CtrlLib/ChWin32.cpp
+++ b/uppsrc/CtrlLib/ChWin32.cpp
@@ -601,8 +601,9 @@ void ChHostSkin()
 		{
 			MenuBar::Style& s = MenuBar::StyleDefault().Write();
 			if(vista_aero) {
-				s.topitemtext[0] = s.topitemtext[1] = s.topitemtext[2] =
-					s.itemtext = XpColor(XP_MENU, 8 /*MENU_POPUPITEM*/,
+				s.topitemtext[0] = s.topitemtext[1] = s.topitemtext[2] = XpColor(XP_MENU, 8 /*MENU_BARITEM*/,
+					2 /*HOT*/, 3803/*TMT_TEXTCOLOR*/);
+				s.itemtext = XpColor(XP_MENU, 14 /*MENU_POPUPITEM*/,
 					2 /*HOT*/, 3803/*TMT_TEXTCOLOR*/);
 				Win32Look(s.item, XP_MENU, 14 /*MENU_POPUPITEM*/, 2 /*HOT*/);
 				Win32Look(s.topitem[1], XP_MENU, 8 , 2 /*HOT*/);


### PR DESCRIPTION
Windows 11 default them treats MENU_BARITEM and MENU_POPUPITEM differently. In the current CtrlLib implementation we always read value from the first thing, which is not always accurate and cause issue like invisible text in selected items in menubar. It can be improved by chaining code responsible for reading system theme.

Without fix (Win11):
![MenuBarWrongColorWin11](https://user-images.githubusercontent.com/6963025/191622693-32325d78-46a0-4f9d-9872-ff63f8c9a0f4.png)

After fix (Win11):
![MenuBarFix](https://user-images.githubusercontent.com/6963025/191622287-bfd63614-9f72-493e-b7e5-06808bcea638.png)

Mirek, if you will be merging this please verify on Windows 10. I think everything should be fine, but it is definitely worth checking. Thanks!

----------------------------------
For comparison reason, this is screenshot from the desktop menubar:
![MenuBarDesktop](https://user-images.githubusercontent.com/6963025/191849506-9622c826-3047-4b2f-98bd-18768e89a2a1.png)
