### PR TITLE
Fix for blank dialog icons in standard dialogs on GTK backend

### DIFF
--- a/uppsrc/CtrlLib/ChGtk3.cpp
+++ b/uppsrc/CtrlLib/ChGtk3.cpp
@@ -280,6 +280,16 @@ Image Gtk_IconAdjusted(const char *icon_name, int size)
 	return m;
 }
 
+void Gtk_OverrideCtrlImgIcon(int i, const char *s)
+{
+	auto icon = Gtk_Icon(s, DPI(48));
+	if (icon.IsEmpty()) {
+		return;
+	}
+	
+	CtrlImg::Set(i, icon);
+}
+
 void ChHostSkin()
 {
 	SetupFont();
@@ -410,19 +420,18 @@ void ChHostSkin()
 		}
 	}
 
-	auto DialogIcon = [](int i, const char *s) { CtrlImg::Set(i, Gtk_Icon(s, DPI(48))); };
 	if (!gtk_check_version(3, 10, 0)) {
-		DialogIcon(CtrlImg::I_information, "dialog-information");
-		DialogIcon(CtrlImg::I_question, "dialog-question");
-		DialogIcon(CtrlImg::I_exclamation, "dialog-warning");
-		DialogIcon(CtrlImg::I_error, "dialog-error");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_information, "dialog-information");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_question, "dialog-question");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_exclamation, "dialog-warning");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_error, "dialog-error");
 	} else {
 		// gtk-dialog-* icons deprecated since 3.10 version (2013-09-23)
 		// https://docs.gtk.org/gtk3/const.STOCK_DIALOG_INFO.html
-		DialogIcon(CtrlImg::I_information, "gtk-dialog-info");
-		DialogIcon(CtrlImg::I_question, "gtk-dialog-question");
-		DialogIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
-		DialogIcon(CtrlImg::I_error, "gtk-dialog-error");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_information, "gtk-dialog-info");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_question, "gtk-dialog-question");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
+		Gtk_OverrideCtrlImgIcon(CtrlImg::I_error, "gtk-dialog-error");
 	}
 	
 	YesButtonImage_Write(Gtk_IconAdjusted("gtk-yes", DPI(16)));

--- a/uppsrc/CtrlLib/ChGtk3.cpp
+++ b/uppsrc/CtrlLib/ChGtk3.cpp
@@ -280,7 +280,7 @@ Image Gtk_IconAdjusted(const char *icon_name, int size)
 	return m;
 }
 
-void Gtk_OverrideCtrlImgIcon(int i, const char *s)
+void Gtk_OverrideDialogIcon(int i, const char *s)
 {
 	auto icon = Gtk_Icon(s, DPI(48));
 	if (icon.IsEmpty()) {
@@ -421,17 +421,17 @@ void ChHostSkin()
 	}
 
 	if (!gtk_check_version(3, 10, 0)) {
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_information, "dialog-information");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_question, "dialog-question");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_exclamation, "dialog-warning");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_error, "dialog-error");
+		Gtk_OverrideDialogIcon(CtrlImg::I_information, "dialog-information");
+		Gtk_OverrideDialogIcon(CtrlImg::I_question, "dialog-question");
+		Gtk_OverrideDialogIcon(CtrlImg::I_exclamation, "dialog-warning");
+		Gtk_OverrideDialogIcon(CtrlImg::I_error, "dialog-error");
 	} else {
 		// gtk-dialog-* icons deprecated since 3.10 version (2013-09-23)
 		// https://docs.gtk.org/gtk3/const.STOCK_DIALOG_INFO.html
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_information, "gtk-dialog-info");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_question, "gtk-dialog-question");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
-		Gtk_OverrideCtrlImgIcon(CtrlImg::I_error, "gtk-dialog-error");
+		Gtk_OverrideDialogIcon(CtrlImg::I_information, "gtk-dialog-info");
+		Gtk_OverrideDialogIcon(CtrlImg::I_question, "gtk-dialog-question");
+		Gtk_OverrideDialogIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
+		Gtk_OverrideDialogIcon(CtrlImg::I_error, "gtk-dialog-error");
 	}
 	
 	YesButtonImage_Write(Gtk_IconAdjusted("gtk-yes", DPI(16)));

--- a/uppsrc/CtrlLib/ChGtk3.cpp
+++ b/uppsrc/CtrlLib/ChGtk3.cpp
@@ -314,11 +314,6 @@ void ChHostSkin()
 
 	ChBaseSkin();
 
-#if 0 // TODO (?)
-		{ SColorLight_Write, 2*5 + 0 },
-		{ SColorShadow_Write, 3*5 + 0 },
-#endif
-
 	Gtk_New("radiobutton radio");
 	SOImages(CtrlsImg::I_S0, GTK_STATE_FLAG_NORMAL);
 	SOImages(CtrlsImg::I_S1, GTK_STATE_FLAG_CHECKED);
@@ -416,10 +411,19 @@ void ChHostSkin()
 	}
 
 	auto DialogIcon = [](int i, const char *s) { CtrlImg::Set(i, Gtk_Icon(s, DPI(48))); };
-	DialogIcon(CtrlImg::I_information, "gtk-dialog-info");
-	DialogIcon(CtrlImg::I_question, "gtk-dialog-question");
-	DialogIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
-	DialogIcon(CtrlImg::I_error, "gtk-dialog-error");
+	if (!gtk_check_version(3, 10, 0)) {
+		DialogIcon(CtrlImg::I_information, "dialog-information");
+		DialogIcon(CtrlImg::I_question, "dialog-question");
+		DialogIcon(CtrlImg::I_exclamation, "dialog-warning");
+		DialogIcon(CtrlImg::I_error, "dialog-error");
+	} else {
+		// gtk-dialog-* icons deprecated since 3.10 version (2013-09-23)
+		// https://docs.gtk.org/gtk3/const.STOCK_DIALOG_INFO.html
+		DialogIcon(CtrlImg::I_information, "gtk-dialog-info");
+		DialogIcon(CtrlImg::I_question, "gtk-dialog-question");
+		DialogIcon(CtrlImg::I_exclamation, "gtk-dialog-warning");
+		DialogIcon(CtrlImg::I_error, "gtk-dialog-error");
+	}
 	
 	YesButtonImage_Write(Gtk_IconAdjusted("gtk-yes", DPI(16)));
 	NoButtonImage_Write(Gtk_IconAdjusted("gtk-no", DPI(16)));

--- a/uppsrc/CtrlLib/ChGtk3.cpp
+++ b/uppsrc/CtrlLib/ChGtk3.cpp
@@ -426,7 +426,7 @@ void ChHostSkin()
 		Gtk_OverrideDialogIcon(CtrlImg::I_exclamation, "dialog-warning");
 		Gtk_OverrideDialogIcon(CtrlImg::I_error, "dialog-error");
 	} else {
-		// gtk-dialog-* icons deprecated since 3.10 version (2013-09-23)
+		// gtk-dialog-* icons deprecated since 3.10 version (2013-09-23) in favor of dialog-*
 		// https://docs.gtk.org/gtk3/const.STOCK_DIALOG_INFO.html
 		Gtk_OverrideDialogIcon(CtrlImg::I_information, "gtk-dialog-info");
 		Gtk_OverrideDialogIcon(CtrlImg::I_question, "gtk-dialog-question");


### PR DESCRIPTION
Since GTK version 3.10 icons names for dialog elements such as information, warning, error and exclamations has been deprecated. On newest version our current loading approach doesn't work at all. To eliminate the issue we need new theme string for GTK version 3.10 and above.

What's new:
- dedicated code for loading dialog icon for GTK version 3.10 and above
- more secure approach of loading GTK icons, if it fails stock icons are used instead of null one

We can remove if statment completly if we do not want to support GTK priori to version 3.10. 3.10 version was release on 2013-09-23. There is very little chances that some distribution are using it even with long term support.

Information about deprecation can be find [here](https://docs.gtk.org/gtk3/const.STOCK_DIALOG_INFO.html).