### PR TITLE
VirtualGui fixes (crash & compilation error)

### DIFF
--- a/uppsrc/VirtualGui/Ctrl.h
+++ b/uppsrc/VirtualGui/Ctrl.h
@@ -42,6 +42,8 @@ private:
 
 	static void DeleteDesktopTop();
 
+	static int    GetCaretBlinkTime()               { return 500; }
+	
 protected:
 	static int PaintLock;
 

--- a/uppsrc/VirtualGui/Wnd.cpp
+++ b/uppsrc/VirtualGui/Wnd.cpp
@@ -74,10 +74,12 @@ Ctrl *Ctrl::GetOwner()
 {
 	GuiLock __;
 	int q = FindTopCtrl();
-	Top *top = topctrl[q]->GetTop();
-	if(q > 0 && top) {
-		Ctrl *x = top->owner_window;
-		return dynamic_cast<TopWindowFrame *>(x) ? x->GetOwner() : x;
+	if(q >= 0) {
+		Top *top = topctrl[q]->GetTop();
+		if(q > 0 && top) {
+			Ctrl *x = top->owner_window;
+			return dynamic_cast<TopWindowFrame *>(x) ? x->GetOwner() : x;
+		}
 	}
 	return NULL;
 }


### PR DESCRIPTION
This patch aims to deal with two urgent issues in VirtualGui:

- Fixes a crash in Ctrl::GetOwner() by implementing a proper bounds checking.
- Fixes a compilation error, by adding the missing static GetCaretBlinkTime() function.

Both issue is present right from the start when checked with Turtle/WebWordExample

Please review.