### PR TITLE
Remove unused variable for ARM in Ops.h (Core)

### DIFF
--- a/uppsrc/Core/Ops.h
+++ b/uppsrc/Core/Ops.h
@@ -230,7 +230,6 @@ byte addc64(uint64& result, const uint64& value, byte carry) {
 force_inline
 byte addc64(uint64& r, uint64 a, byte carry)
 {
-	uint64_t r1 = r;
 	r += a + carry;
 	return carry ? r <= a : r < a;
 }


### PR DESCRIPTION
uint64_t r1 =r is not used and should be removed from addc64 function.