### PR TITLE
Eliminating compilation warning from CtrlLib::PopUpList class

### DIFF
--- a/uppsrc/CtrlLib/DropChoice.h
+++ b/uppsrc/CtrlLib/DropChoice.h
@@ -80,7 +80,7 @@ protected:
 	
 	void          Reset();
 	
-	friend class Popup;
+	friend struct Popup;
 
 public:
 	Event<>      WhenCancel;


### PR DESCRIPTION
friend declaration should do not mix class with struct. So, if the parent structure is declare as struct in friend operation we should use exactly the same keyword. In the context of our code PopUpList has this problem.

Tested with ARM Clang on macOS.