### PR TITLE
IDE: Android Builder update to 2022 stack

### DIFF
--- a/examples/AndroidMath/AndroidManifest.xml
+++ b/examples/AndroidMath/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.upp.AndroidMath">
+	<uses-sdk android:minSdkVersion="21" />
     <application
 		android:allowBackup="true">
         <activity android:name=".AndroidMathActivity"

--- a/uppsrc/ide/Android/Android.h
+++ b/uppsrc/ide/Android/Android.h
@@ -65,8 +65,11 @@ public:
 	String PlatformToolsDir() const;
 	String ToolsDir() const;
 	
+	bool HasD8() const;
+	
 	String AaptPath() const       { return ConcreteBuildToolsDir() + DIR_SEPS + "aapt" + GetExeExt(); }
 	String DxPath() const         { return ConcreteBuildToolsDir() + DIR_SEPS + "dx" + Android::GetScriptExt(); }
+	String D8Path() const         { return ConcreteBuildToolsDir() + DIR_SEPS + "d8" + Android::GetScriptExt(); }
 	String ZipalignPath() const   { return ConcreteBuildToolsDir() + DIR_SEPS + "zipalign" + GetExeExt(); }
 	String AndroidJarPath() const { return ConcretePlatformDir() + DIR_SEPS + "android.jar"; }
 	String AdbPath() const        { return PlatformToolsDir() + DIR_SEPS + "adb" + GetExeExt(); }

--- a/uppsrc/ide/Android/Android.h
+++ b/uppsrc/ide/Android/Android.h
@@ -68,6 +68,7 @@ public:
 	bool HasD8() const;
 	
 	String AaptPath() const       { return ConcreteBuildToolsDir() + DIR_SEPS + "aapt" + GetExeExt(); }
+	String ApksignerPath() const  { return ConcreteBuildToolsDir() + DIR_SEPS + "apksigner" + Android::GetScriptExt(); }
 	String DxPath() const         { return ConcreteBuildToolsDir() + DIR_SEPS + "dx" + Android::GetScriptExt(); }
 	String D8Path() const         { return ConcreteBuildToolsDir() + DIR_SEPS + "d8" + Android::GetScriptExt(); }
 	String ZipalignPath() const   { return ConcreteBuildToolsDir() + DIR_SEPS + "zipalign" + GetExeExt(); }

--- a/uppsrc/ide/Android/Android.h
+++ b/uppsrc/ide/Android/Android.h
@@ -85,16 +85,16 @@ public:
 public:
 	String GetPath() const              { return this->path; }
 	String GetPlatform() const          { return this->platform; }
-	String GetBuildToolsRelease() const { return this->buildToolsRelease; }
+	String GetBuildToolsRelease() const { return this->build_tools_release; }
 	
 	void SetPath(const String& path)                           { this->path = path; }
 	void SetPlatform(const String& platform)                   { this->platform = platform; }
-	void SetBuildToolsRelease(const String& buildToolsRelease) { this->buildToolsRelease = buildToolsRelease; }
+	void SetBuildToolsRelease(const String& build_tools_release) { this->build_tools_release = build_tools_release; }
 	
 private:
 	String path;
 	String platform;
-	String buildToolsRelease;
+	String build_tools_release;
 };
 
 class AndroidNDK {
@@ -155,11 +155,26 @@ private:
 
 class AndroidManifest {
 public:
-	AndroidManifest();
+	static constexpr const char* FILE_NAME = "AndroidManifest.xml";
+	
+	class UsesSdk {
+	public:
+		int minSdkVersion    = Null;
+		int targetSdkVersion = Null;
+		int maxSdkVersion    = Null;
+	};
+	
+public:
+	AndroidManifest(const String& path);
 	virtual ~AndroidManifest();
 	
-private:
+	bool Parse();
 	
+public:
+	One<UsesSdk> uses_sdk;
+	
+private:
+	String path;
 };
 
 }

--- a/uppsrc/ide/Android/Android.h
+++ b/uppsrc/ide/Android/Android.h
@@ -76,11 +76,6 @@ public:
 	String AdbPath() const        { return PlatformToolsDir() + DIR_SEPS + "adb" + GetExeExt(); }
 	String AndroidPath() const    { return ToolsDir() + DIR_SEPS + "android" + Android::GetScriptExt(); }
 	String EmulatorPath() const   { return ToolsDir() + DIR_SEPS + "emulator" + GetExeExt(); }
-	String MonitorPath() const    { return ToolsDir() + DIR_SEPS + "monitor" + Android::GetScriptExt(); }
-	
-public:
-	String GetLauchSDKManagerCmd() const { return NormalizeExePath(AndroidPath()) + " sdk"; }
-	String GetLauchAVDManagerCmd() const { return NormalizeExePath(AndroidPath()) + " avd"; }
 	
 public:
 	String GetPath() const              { return this->path; }

--- a/uppsrc/ide/Android/AndroidManifest.cpp
+++ b/uppsrc/ide/Android/AndroidManifest.cpp
@@ -1,15 +1,49 @@
 #include "Android.h"
 
+#define METHOD_NAME "AndroidManifest::" << UPP_FUNCTION_NAME << "(): "
+
 namespace Upp {
 
-AndroidManifest::AndroidManifest()
+AndroidManifest::AndroidManifest(const String& path)
+	: path(path)
 {
-	
 }
 
 AndroidManifest::~AndroidManifest()
 {
+}
+
+bool AndroidManifest::Parse()
+{
+	String xml = LoadFile(path);
+	if (xml.IsVoid()) {
+		Loge() << METHOD_NAME << "Failed to load manifest file \"" + path + "\".";
+		return false;
+	}
 	
+	try {
+		XmlParser p(xml);
+		while(!p.IsTag()) {
+			p.Skip();
+		}
+		p.PassTag("manifest");
+		while (!p.End()) {
+			if(p.TagE("uses-sdk")) {
+				uses_sdk.Create();
+				
+				uses_sdk->minSdkVersion = p.Int("android:minSdkVersion");
+				uses_sdk->targetSdkVersion = p.Int("android:targetSdkVersion");
+				uses_sdk->maxSdkVersion = p.Int("android:maxSdkVersion");
+			}
+			
+			p.Skip();
+		}
+	} catch(const XmlError& e) {
+		Loge() << METHOD_NAME << "Failed to parse manifest file with error \"" + e + "\".";
+		return false;
+	}
+	
+	return true;
 }
 
 }

--- a/uppsrc/ide/Android/AndroidSDK.cpp
+++ b/uppsrc/ide/Android/AndroidSDK.cpp
@@ -37,7 +37,7 @@ void AndroidSDK::DeducePlatform()
 
 void AndroidSDK::DeduceBuildToolsRelease()
 {
-	buildToolsRelease = FindDefaultBuildToolsRelease();
+	build_tools_release = FindDefaultBuildToolsRelease();
 }
 
 bool AndroidSDK::Validate() const
@@ -224,7 +224,7 @@ String AndroidSDK::PlatformsDir() const
 
 String AndroidSDK::ConcreteBuildToolsDir() const
 {
-	return BuildToolsDir() + DIR_SEPS + buildToolsRelease;
+	return BuildToolsDir() + DIR_SEPS + build_tools_release;
 }
 
 String AndroidSDK::ConcretePlatformDir() const

--- a/uppsrc/ide/Android/AndroidSDK.cpp
+++ b/uppsrc/ide/Android/AndroidSDK.cpp
@@ -244,4 +244,9 @@ String AndroidSDK::ToolsDir() const
 
 // ---------------------------------------------------------------
 
+bool AndroidSDK::HasD8() const
+{
+	return FileExists(D8Path());
+}
+
 }

--- a/uppsrc/ide/Builders/Android.h
+++ b/uppsrc/ide/Builders/Android.h
@@ -20,8 +20,8 @@ public:
 	String GetResDir() const;
 	String GetBuildDir() const;
 	String GetClassesDir() const;
-	String GetBinDir() const;
 	String GetIntermediatesDir() const;
+	String GetBinDir() const;
 	String GetObjDir() const;
 	String GetObjLocalDir() const;
 	

--- a/uppsrc/ide/Builders/Android.h
+++ b/uppsrc/ide/Builders/Android.h
@@ -21,12 +21,15 @@ public:
 	String GetBuildDir() const;
 	String GetClassesDir() const;
 	String GetBinDir() const;
+	String GetIntermediatesDir() const;
 	String GetObjDir() const;
 	String GetObjLocalDir() const;
 	
 	String GetManifestPath() const;
 	String GetJniMakeFilePath() const;
 	String GetJniApplicationMakeFilePath() const;
+	
+	Vector<String> GetClassessFiles() const;
 	
 	bool IsDebug() const;
 	bool IsRelease() const;

--- a/uppsrc/ide/Builders/AndroidBuilder.cpp
+++ b/uppsrc/ide/Builders/AndroidBuilder.cpp
@@ -740,7 +740,7 @@ bool AndroidBuilder::GenerateDexFileUsingD8()
 	const auto outputFile = project->GetIntermediatesDir() << DIR_SEPS << "classes.jar";
 		
 	cmd << NormalizeExePath(sdk.D8Path());
-	cmd << " --output=" << outputFile << " ";
+	cmd << " --output " << outputFile << " ";
 	auto classesFiles = project->GetClassessFiles();
 	for (const auto& file : classesFiles) {
 		cmd << file << " ";

--- a/uppsrc/ide/Builders/AndroidBuilder.cpp
+++ b/uppsrc/ide/Builders/AndroidBuilder.cpp
@@ -495,8 +495,7 @@ bool AndroidBuilder::SignApk(const String& target, const String& unsignedApkPath
 	
 	String cmd;
 	cmd << NormalizeExePath(sdk.ApksignerPath());
-	cmd << " sign --ks " << keystorePath << " --ks-pass pass:android" << " --out " << target << " " << unsignedApkPath;
-	PutConsole(cmd);
+	cmd << " sign --ks " << keystorePath << " --ks-pass pass:android" << " --out " << signedApkPath << " " << unsignedApkPath;
 	if(Execute(cmd, ss) != 0) {
 		PutConsole(ss.GetResult());
 		return false;
@@ -735,7 +734,6 @@ bool AndroidBuilder::GenerateDexFileUsingD8()
 	String currentDir = GetCurrentDirectory();
 	ChangeCurrentDirectory(project->GetBinDir());
 	cmd << NormalizeExePath(jdk->GetJarPath()) << " xf " << outputFile;
-	PutConsole(cmd);
 	if(Execute(cmd, ss) != 0) {
 		ChangeCurrentDirectory(currentDir);
 		PutConsole(ss.GetResult());

--- a/uppsrc/ide/Builders/AndroidBuilder.h
+++ b/uppsrc/ide/Builders/AndroidBuilder.h
@@ -68,6 +68,7 @@ protected:
 	void GenerateApplicationMakeFile();
 	void GenerateMakeFile();
 	bool GenerateRFile();
+	bool GenerateDexFile();
 	
 protected:
 	bool ValidateBuilderEnviorement();

--- a/uppsrc/ide/Builders/AndroidBuilder.h
+++ b/uppsrc/ide/Builders/AndroidBuilder.h
@@ -76,6 +76,7 @@ protected:
 	bool ValidateBuilderEnviorement();
 	void PutErrorOnConsole(const String& msg);
 	
+	bool AlignApk(const String& target, const String& unsignedApkPath);
 	bool SignApk(const String& target, const String& unsignedApkPath);
 	bool GenerateDebugKey(const String& keystorePath);
 	

--- a/uppsrc/ide/Builders/AndroidBuilder.h
+++ b/uppsrc/ide/Builders/AndroidBuilder.h
@@ -103,6 +103,7 @@ private:
 	One<Jdk>                    jdk;
 	One<AndroidProject>         project;
 	One<AndroidBuilderCommands> commands;
+	One<AndroidManifest>        manifest;
 	
 	const Workspace&            wspc;
 

--- a/uppsrc/ide/Builders/AndroidBuilder.h
+++ b/uppsrc/ide/Builders/AndroidBuilder.h
@@ -69,6 +69,8 @@ protected:
 	void GenerateMakeFile();
 	bool GenerateRFile();
 	bool GenerateDexFile();
+	bool GenerateDexFileUsingD8();
+	bool GenerateDexFileUsingDx();
 	
 protected:
 	bool ValidateBuilderEnviorement();

--- a/uppsrc/ide/Builders/AndroidProject.cpp
+++ b/uppsrc/ide/Builders/AndroidProject.cpp
@@ -50,7 +50,12 @@ String AndroidProject::GetBuildDir() const
 
 String AndroidProject::GetClassesDir() const
 {
-	return this->dir + DIR_SEPS + "classes";
+	return GetIntermediatesDir() + DIR_SEPS + "classes";
+}
+
+String AndroidProject::GetIntermediatesDir() const
+{
+	return this->dir + DIR_SEPS + "intermediates";
 }
 
 String AndroidProject::GetBinDir() const

--- a/uppsrc/ide/Builders/AndroidProject.cpp
+++ b/uppsrc/ide/Builders/AndroidProject.cpp
@@ -87,6 +87,37 @@ String AndroidProject::GetJniApplicationMakeFilePath() const
 
 // -------------------------------------------------------------------
 
+Vector<String> AndroidProject::GetClassessFiles() const
+{
+	BiVector<String> dirs = { GetClassesDir() };
+	
+	Vector<String> classesFiles;
+	while(!dirs.IsEmpty())
+	{
+		for(FindFile ff(AppendFileName(dirs.Head(), "*")); ff; ff.Next()) {
+			if (ff.IsHidden() || ff.IsSymLink()) {
+				continue;
+			}
+			
+			auto path = ff.GetPath();
+			if (ff.IsFolder()) {
+				dirs.AddTail(path);
+				continue;
+			}
+			
+			if (path.EndsWith(".class")) {
+				classesFiles.Add(path);
+				continue;
+			}
+		}
+		dirs.DropHead();
+	}
+	
+	return classesFiles;
+}
+
+// -------------------------------------------------------------------
+
 bool AndroidProject::IsDebug() const
 {
 	return debug;

--- a/uppsrc/ide/Builders/Build.cpp
+++ b/uppsrc/ide/Builders/Build.cpp
@@ -3,6 +3,8 @@
 
 #include <plugin/bz2/bz2.h>
 
+#define METHOD_NAME "MakeBuild::" << UPP_FUNCTION_NAME << "(): "
+
 #define LDUMP(x) // DUMP(x)
 
 MakeBuild::MakeBuild()
@@ -124,11 +126,21 @@ void MakeBuild::CreateHost(Host& host, const String& method, bool darkmode, bool
 #ifdef PLATFORM_COCOA
 		host.exedirs.Append(SplitDirs("/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")); // sometimes some of these are missing..
 #endif
+		
+		if (IsAndroidMethod(method)) {
+			auto jdkPath = bm.Get("JDK_PATH", "");
+			if (!jdkPath.IsEmpty()) {
+				Cout() << "JDK Path: " << jdkPath << "\n";
+				env.GetAdd("JAVA_HOME") = jdkPath;
+			}
+		}
+		
 		for(int i = 0; i < env.GetCount(); i++) {
 			LDUMP(env.GetKey(i));
 			LDUMP(env[i]);
 			host.environment << env.GetKey(i) << '=' << env[i] << '\0';
 		}
+		
 		host.environment.Cat(0);
 		host.cmdout = &cmdout;
 	}
@@ -149,43 +161,47 @@ One<Builder> MakeBuild::CreateBuilder(Host *host)
 	if(q < 0) {
 		PutConsole("Invalid builder " + builder);
 		ConsoleShow();
-		return NULL;
+		return nullptr;
 	}
 	Builder* b = (*BuilderMap().Get(builder))();
 	b->host = host;
 	b->script = bm.Get("SCRIPT", "");
 	if(AndroidBuilder::GetBuildersNames().Find(builder) > -1) {
-		AndroidBuilder* ab = dynamic_cast<AndroidBuilder*>(b);
-		ab->sdk.SetPath((bm.Get("SDK_PATH", "")));
-		ab->ndk.SetPath((bm.Get("NDK_PATH", "")));
-		ab->SetJdk(One<Jdk>(new Jdk(bm.Get("JDK_PATH", ""), host)));
+		AndroidBuilder* pAb = dynamic_cast<AndroidBuilder*>(b);
+		if (!pAb) {
+			Loge() << METHOD_NAME << "Converting builder to android builder failed.";
+			return nullptr;
+		}
+		pAb->sdk.SetPath((bm.Get("SDK_PATH", "")));
+		pAb->ndk.SetPath((bm.Get("NDK_PATH", "")));
+		pAb->SetJdk(One<Jdk>(new Jdk(bm.Get("JDK_PATH", ""), host)));
 		
 		String platformVersion = bm.Get("SDK_PLATFORM_VERSION", "");
 		if(!platformVersion.IsEmpty())
-			ab->sdk.SetPlatform(platformVersion);
+			pAb->sdk.SetPlatform(platformVersion);
 		else
-			ab->sdk.DeducePlatform();
+			pAb->sdk.DeducePlatform();
 		String buildToolsRelease = bm.Get("SDK_BUILD_TOOLS_RELEASE", "");
 		if(!buildToolsRelease.IsEmpty())
-			ab->sdk.SetBuildToolsRelease(buildToolsRelease);
+			pAb->sdk.SetBuildToolsRelease(buildToolsRelease);
 		else
-			ab->sdk.DeduceBuildToolsRelease();
+			pAb->sdk.DeduceBuildToolsRelease();
 		
-		ab->ndk_blitz = bm.Get("NDK_BLITZ", "") == "1";
+		pAb->ndk_blitz = bm.Get("NDK_BLITZ", "") == "1";
 		if(bm.Get("NDK_ARCH_ARMEABI_V7A", "") == "1")
-			ab->ndkArchitectures.Add("armeabi-v7a");
+			pAb->ndkArchitectures.Add("armeabi-v7a");
 		if(bm.Get("NDK_ARCH_ARM64_V8A", "") == "1")
-			ab->ndkArchitectures.Add("arm64-v8a");
+			pAb->ndkArchitectures.Add("arm64-v8a");
 		if(bm.Get("NDK_ARCH_X86", "") == "1")
-			ab->ndkArchitectures.Add("x86");
+			pAb->ndkArchitectures.Add("x86");
 		if(bm.Get("NDK_ARCH_X86_64", "") == "1")
-			ab->ndkArchitectures.Add("x86_64");
-		ab->ndkToolchain = bm.Get("NDK_TOOLCHAIN", "");
-		ab->ndkCppRuntime = bm.Get("NDK_CPP_RUNTIME", "");
-		ab->ndkCppFlags = bm.Get("NDK_COMMON_CPP_OPTIONS", "");
-		ab->ndkCFlags = bm.Get("NDK_COMMON_C_OPTIONS", "");
+			pAb->ndkArchitectures.Add("x86_64");
+		pAb->ndkToolchain = bm.Get("NDK_TOOLCHAIN", "");
+		pAb->ndkCppRuntime = bm.Get("NDK_CPP_RUNTIME", "");
+		pAb->ndkCppFlags = bm.Get("NDK_COMMON_CPP_OPTIONS", "");
+		pAb->ndkCFlags = bm.Get("NDK_COMMON_C_OPTIONS", "");
 		
-		b = ab;
+		b = pAb;
 	}
 	else {
 		// TODO: cpp builder variables only!!!
@@ -594,4 +610,22 @@ void MakeBuild::RebuildAll()
 String MakeBuild::GetInvalidBuildMethodError(const String& method)
 {
 	return "Invalid build method " + method + " (" + GetMethodPath(method) + ").";
+}
+
+bool MakeBuild::IsAndroidMethod(const String& method) const
+{
+	VectorMap<String, String> bm = GetMethodVars(method);
+	String builder = bm.Get("BUILDER", "");
+	if (builder.IsEmpty()) {
+		Loge() << METHOD_NAME << "Failed to find builder.";
+		return false;
+	}
+	
+	auto pBuilder = (*BuilderMap().Get(builder))();
+	if (!pBuilder) {
+		Loge() << METHOD_NAME << "Failed to get builder from builder map.";
+		return false;
+	}
+	
+	return AndroidBuilder::GetBuildersNames().Find(builder) > -1;
 }

--- a/uppsrc/ide/Builders/Build.h
+++ b/uppsrc/ide/Builders/Build.h
@@ -97,6 +97,7 @@ public:
 
 private:
 	static String GetInvalidBuildMethodError(const String& method);
+	bool IsAndroidMethod(const String& method) const;
 };
 
 extern bool output_per_assembly;

--- a/uppsrc/ide/ide.h
+++ b/uppsrc/ide/ide.h
@@ -966,7 +966,6 @@ public:
 		void  SetupAndroidMobilePlatform(Bar& bar, const AndroidSDK& androidSDK);
 		void  LaunchAndroidSDKManager(const AndroidSDK& androidSDK);
 		void  LaunchAndroidAVDManager(const AndroidSDK& androidSDK);
-		void  LauchAndroidDeviceMonitor(const AndroidSDK& androidSDK);
 
 	void      AssistMenu(Bar& menu);
 	void      BrowseMenu(Bar& menu);

--- a/uppsrc/ide/idebar.cpp
+++ b/uppsrc/ide/idebar.cpp
@@ -425,9 +425,8 @@ void Ide::SetupMobilePlatforms(Bar& menu)
 
 void Ide::SetupAndroidMobilePlatform(Bar& menu, const AndroidSDK& androidSDK)
 {
-	menu.Add("SDK Manager", THISBACK1(LaunchAndroidSDKManager, androidSDK));
-	menu.Add("AVD Manager", THISBACK1(LaunchAndroidAVDManager, androidSDK));
-	menu.Add("Device monitor", THISBACK1(LauchAndroidDeviceMonitor, androidSDK));
+	menu.Add("SDK Manager", [=] { LaunchAndroidSDKManager(androidSDK); });
+	menu.Add("AVD Manager", [=] { LaunchAndroidAVDManager(androidSDK); });
 }
 
 void Ide::ProjectRepo(Bar& menu)

--- a/uppsrc/ide/idetool.cpp
+++ b/uppsrc/ide/idetool.cpp
@@ -573,21 +573,10 @@ void Ide::RemoveDs()
 
 void Ide::LaunchAndroidSDKManager(const AndroidSDK& androidSDK)
 {
-	Host host;
-	CreateHost(host, darkmode, disable_uhd);
-	IGNORE_RESULT(host.Execute(androidSDK.GetLauchSDKManagerCmd()));
+	PromptOK("SDK managment is not yet implemented in TheIDE. Use Android Studio for this purpose instead.");
 }
 
 void Ide::LaunchAndroidAVDManager(const AndroidSDK& androidSDK)
 {
-	Host host;
-	CreateHost(host, darkmode, disable_uhd);
-	IGNORE_RESULT(host.Execute(androidSDK.GetLauchAVDManagerCmd()));
-}
-
-void Ide::LauchAndroidDeviceMonitor(const AndroidSDK& androidSDK)
-{
-	Host host;
-	CreateHost(host, darkmode, disable_uhd);
-	IGNORE_RESULT(host.Execute(androidSDK.MonitorPath()));
+	PromptOK("AVD managment is not yet implemented in TheIDE. Use Android Studio for this purpose instead.");
 }


### PR DESCRIPTION
Android Builder was modernized to the latest Google stacks. It is compatible with latest build tools version (33) and android (13).

The following PR covers:
- Migration from deprecated DX to D8
- Migrate from deprecated jarsigner to apksigner
- Android Builder works now for both POSIX and Windows
- There is no possibility to lunch SDK and AVD managers, the tools that we spawned previously are deprecated. We will need to write our own wrappers for console tools if we want to support that. 
- Android Builder now parsers AndroidManifest.xml file and informs Android NDK project about minAndroidSdk version from this file. This helps to avoid warnings in the build process.