### PR TITLE
one possible bugfix, and few more small changes to lower amount of warnings while building ide

### DIFF
--- a/uppsrc/Core/Mt.cpp
+++ b/uppsrc/Core/Mt.cpp
@@ -270,8 +270,8 @@ void Thread::DumpDiagnostics()
 			               PTHREAD_EXPLICIT_SCHED, "PTHREAD_EXPLICIT_SCHED",
 			               "UNKNOWN getinheritsched VALUE"));
 	
-		if(pthread_attr_getschedpolicy(attr, &i) == 0)
-			RLOG(decode(i, SCHED_OTHER, "SCHED_OTHER",
+		if(pthread_attr_getschedpolicy(attr, &s) == 0)
+			RLOG(decode(s, SCHED_OTHER, "SCHED_OTHER",
 			               SCHED_FIFO, "SCHED_FIFO",
 			               SCHED_RR, "SCHED_RR",
 			               SCHED_IDLE, "SCHED_IDLE",

--- a/uppsrc/Core/Stream.cpp
+++ b/uppsrc/Core/Stream.cpp
@@ -234,7 +234,7 @@ int Stream::GetUtf8()
 		return code;
 	
 	if(code >= 0xC2) {
-		int c = 0, pos = GetPos();
+		int c = 0;
 		if(code < 0xE0) {
 			int c0 = Get();
 			if(c0 >= 0x80 && c0 < 0xC0 &&

--- a/uppsrc/CtrlCore/CtrlDraw.cpp
+++ b/uppsrc/CtrlCore/CtrlDraw.cpp
@@ -279,7 +279,6 @@ void Ctrl::CtrlPaint(SystemDraw& w, const Rect& clip) {
 	Rect orect = rect.Inflated(overpaint);
 	if(!IsShown() || orect.IsEmpty() || clip.IsEmpty() || !clip.Intersects(orect))
 		return;
-	Ctrl *q;
 	Rect view = rect;
 	int n = GetFrameCount();
 	for(int i = 0; i < n; i++) {

--- a/uppsrc/CtrlCore/GtkEvent.cpp
+++ b/uppsrc/CtrlCore/GtkEvent.cpp
@@ -342,7 +342,6 @@ void Ctrl::IMCommit(GtkIMContext *context, gchar *str, gpointer user_data)
 void Ctrl::IMLocation(Ctrl *w)
 {
 	if(w && w->HasFocusDeep() && focusCtrl && !IsNull(focusCtrl->GetPreedit())) {
-		GdkRectangle r;
 		Rect e = w->GetPreeditScreenRect();
 		Rect q = w->GetScreenRect();
 		GdkRectangle gr;

--- a/uppsrc/CtrlLib/DropChoice.h
+++ b/uppsrc/CtrlLib/DropChoice.h
@@ -80,7 +80,7 @@ protected:
 	
 	void          Reset();
 	
-	friend class Popup;
+	friend struct Popup;
 
 public:
 	Event<>      WhenCancel;

--- a/uppsrc/CtrlLib/PopUpList.cpp
+++ b/uppsrc/CtrlLib/PopUpList.cpp
@@ -68,7 +68,7 @@ void PopUpList::SetLineCy(int ii, int cy)
 {
 	ASSERT(cy >= 0 && cy < 32000);
 	word& x = lineinfo.At(ii, 0x7fff);
-	x = x & 0x8000 | cy;
+	x = (x & 0x8000) | cy;
 	if(popup)
 		popup->ac.SetLineCy(ii, cy);
 }

--- a/uppsrc/CtrlLib/ScrollBar.cpp
+++ b/uppsrc/CtrlLib/ScrollBar.cpp
@@ -64,7 +64,6 @@ int ScrollBar::ButtonCount() const
 }
 
 void ScrollBar::Layout() {
-	Size sz = GetSize();
 	Set(pagepos);
 	Refresh();
 }

--- a/uppsrc/RichText/TxtPaint.cpp
+++ b/uppsrc/RichText/TxtPaint.cpp
@@ -257,7 +257,6 @@ int   RichTxt::GetPos(int x, PageY y, RichContext rc) const
 RichHotPos RichTxt::GetHotPos(int x, PageY y, int tolerance, RichContext rc) const
 {
 	int parti = 0;
-	int pos = 0;
 	int ti = 0;
 	if(part.GetCount()) {
 		while(parti < part.GetCount()) {
@@ -274,7 +273,6 @@ RichHotPos RichTxt::GetHotPos(int x, PageY y, int tolerance, RichContext rc) con
 			}
 			if(IsTable(parti))
 				ti += 1 + GetTable(parti).GetTableCount();
-			pos += GetPartLength(parti) + 1;
 			parti++;
 			rc = next;
 		}

--- a/uppsrc/ide/About.cpp
+++ b/uppsrc/ide/About.cpp
@@ -74,7 +74,6 @@ Size SplashCtrl::MakeLogo(Ctrl& parent, Array<Ctrl>& ctrl)
 	Label& v1 = ctrl.Create<Label>();
 	l.SetImage(logo);
 	Size sz = Size(isz.cx, isz.cy/* + 80*/);
-	int total = 0;
 
 	Index<String> classes;
 	Index<String> items;

--- a/uppsrc/ide/Browser/CodeRef.cpp
+++ b/uppsrc/ide/Browser/CodeRef.cpp
@@ -161,10 +161,6 @@ String NaturalDeQtf(const char *s) {
 	return String(r);
 }
 
-static int sSplitT(int c) {
-	return c == ';' || c == '<' || c == '>' || c == ',';
-}
-
 String TopicEditor::GetLang() const
 {
 	int q = topicpath.ReverseFind('@');

--- a/uppsrc/ide/clang/Indexer.cpp
+++ b/uppsrc/ide/clang/Indexer.cpp
@@ -404,7 +404,6 @@ void Indexer::SchedulerThread()
 						return job;
 					};
 					int blitz_index = 0;
-					int c_blitz_index = 0;
 					for(const auto& pf : pkg.value) {
 						FileAnnotation0 f;
 						{

--- a/uppsrc/ide/clang/Signature.cpp
+++ b/uppsrc/ide/clang/Signature.cpp
@@ -81,7 +81,6 @@ String CleanupId(const char *s)
 				return memcmp(s, "operator", 8) == 0;
 			};
 
-			const char *b = s;
 			String id;
 			while(iscid(*s) || *s == ':') {
 				id.Cat(*s++);
@@ -94,8 +93,6 @@ String CleanupId(const char *s)
 							break;
 					}
 					SkipT(); // Skip template arguments like in Foo<Bar>::Method() -> Foo::Method
-					b = s;
-					
 				}
 			}
 			if(id == s_attribute) {

--- a/uppsrc/ide/clang/Signature.cpp
+++ b/uppsrc/ide/clang/Signature.cpp
@@ -333,8 +333,8 @@ Vector<ItemTextPart> ParsePretty(const String& name, const String& signature, in
 				s++;
 		}
 		else
-		if(sOperatorTab[*s]) {
-			while(sOperatorTab[s[n]])
+		if(sOperatorTab[uint8(*s)]) {
+			while(sOperatorTab[uint8(s[n])])
 				n++;
 			p.type = ITEM_CPP;
 		}


### PR DESCRIPTION
build platform: KDE neon (based on Ubuntu 22.04), clang 14.0.0 in C++20 mode
(except changing build method to -std=c++20, it's the default CLANG build method after cloning git repository and using make to build IDE from command line)

There are still some warnings left, but some of those can't be resolved as cleanly, the `|` vs `||` would require extra casting to `int`, and some unused variables are used for diagnostic or debug builds. Also I avoided Assist.cpp and Navigator.cpp just in case Mirek is still editing them a lot.