### PR TITLE
possible fix

### DIFF
--- a/uppsrc/Core/Mt.cpp
+++ b/uppsrc/Core/Mt.cpp
@@ -270,8 +270,8 @@ void Thread::DumpDiagnostics()
 			               PTHREAD_EXPLICIT_SCHED, "PTHREAD_EXPLICIT_SCHED",
 			               "UNKNOWN getinheritsched VALUE"));
 	
-		if(pthread_attr_getschedpolicy(attr, &i) == 0)
-			RLOG(decode(i, SCHED_OTHER, "SCHED_OTHER",
+		if(pthread_attr_getschedpolicy(attr, &s) == 0)
+			RLOG(decode(s, SCHED_OTHER, "SCHED_OTHER",
 			               SCHED_FIFO, "SCHED_FIFO",
 			               SCHED_RR, "SCHED_RR",
 			               SCHED_IDLE, "SCHED_IDLE",

--- a/uppsrc/ide/clang/Signature.cpp
+++ b/uppsrc/ide/clang/Signature.cpp
@@ -330,8 +330,8 @@ Vector<ItemTextPart> ParsePretty(const String& name, const String& signature, in
 				s++;
 		}
 		else
-		if(sOperatorTab[*s]) {
-			while(sOperatorTab[s[n]])
+		if(sOperatorTab[uint8(*s)]) {
+			while(sOperatorTab[uint8(s[n])])
 				n++;
 			p.type = ITEM_CPP;
 		}


### PR DESCRIPTION
Seems you left out the most important change to fix the `sOperatorTab` access with signed char.

Was that intentional? To me it looks like logical fix, although I didn't verify how to trigger the bug by source code.

(the change in Mt.cpp is not important, but the Signature.cpp IMO is)