### PR TITLE
Ide, LayDes: Fix issue with VisGen hilighting

### DIFF
--- a/uppsrc/ide/LayDes/LayDes.h
+++ b/uppsrc/ide/LayDes/LayDes.h
@@ -343,7 +343,9 @@ private:
 	bool              usegrid;
 	bool              ignoreminsize;
 	bool              sizespring;
-
+	
+	String            hlStyles;
+	
 	WithMatrixLayout<TopWindow>  matrix;
 	WithSettingLayout<TopWindow> setting;
 
@@ -510,7 +512,7 @@ public:
 	void FindLayout(const String& name, const String& item) { designer.FindLayout(name, item); }
 	String GetCurrentLayout() const             { return designer.GetLayoutName(); }
 
-	LayDesigner()                               { parent.Add(designer.DesignerCtrl().SizePos()); }
+	LayDesigner(const String& hlStyles);
 };
 
 #endif

--- a/uppsrc/ide/LayDes/LayDes.upp
+++ b/uppsrc/ide/LayDes/LayDes.upp
@@ -24,6 +24,7 @@ file
 	laydes.cpp,
 	layfile.cpp,
 	laywin.cpp,
+	laydesigner.cpp,
 	LayDes.lay,
 	LayDes.iml,
 	Info readonly separator,

--- a/uppsrc/ide/LayDes/laydesigner.cpp
+++ b/uppsrc/ide/LayDes/laydesigner.cpp
@@ -1,0 +1,7 @@
+#include "LayDes.h"
+
+LayDesigner::LayDesigner(const String& hlStyles)
+{
+	designer.hlStyles = hlStyles;
+	parent.Add(designer.DesignerCtrl().SizePos());
+}

--- a/uppsrc/ide/LayDes/laywin.cpp
+++ b/uppsrc/ide/LayDes/laywin.cpp
@@ -370,8 +370,13 @@ LayDes::LayDes()
 }
 
 LayDesigner *CreateLayDesigner(
-	const char *filename, byte charset, const char *cfgname, const String& hlStyles)
+	Ide* ide, const char *filename, byte charset, const char *cfgname)
 {
+	String hlStyles;
+	if (ide) {
+		hlStyles = ide->editor.StoreHlStyles();
+	}
+	
 	LayDesigner *q = new LayDesigner(hlStyles);
 	LoadFromGlobal(*q, "laydes-ctrl");
 	if(q->Load(filename, charset))
@@ -406,7 +411,7 @@ struct LayDesModule : public IdeModule {
 	
 	virtual IdeDesigner *CreateDesigner(Ide *ide, const char *path, byte cs) override {
 		if(IsLayFile(path)) {
-			LayDesigner *d = CreateLayDesigner(path, cs, "laydes-ctrl", ide->editor.StoreHlStyles());
+			LayDesigner *d = CreateLayDesigner(ide, path, cs, "laydes-ctrl");
 			return d;
 		}
 		return NULL;

--- a/uppsrc/ide/LayDes/visgen.cpp
+++ b/uppsrc/ide/LayDes/visgen.cpp
@@ -11,7 +11,7 @@ struct VisGenDlg : public WithVisGenLayout<TopWindow> {
 
 	typedef VisGenDlg CLASSNAME;
 
-	VisGenDlg(LayoutData& layout, const Vector<int>& cursor);
+	VisGenDlg(LayoutData& layout, const Vector<int>& cursor, const String& hlStyles);
 };
 
 bool VisGenDlg::HasItem(const char *id)
@@ -248,7 +248,7 @@ void VisGenDlg::Type()
 	Refresh();
 }
 
-VisGenDlg::VisGenDlg(LayoutData& layout, const Vector<int>& cursor)
+VisGenDlg::VisGenDlg(LayoutData& layout, const Vector<int>& cursor, const String& hlStyles)
 :	layout(layout)
 {
 	type <<= 0;
@@ -270,11 +270,11 @@ VisGenDlg::VisGenDlg(LayoutData& layout, const Vector<int>& cursor)
 			
 	name << [=] { Refresh(); };
 	
-
 	Refresh();
 	view.Highlight("cpp");
 	view.HideBar();
 	view.SetFont(CourierZ(12));
+	view.LoadHlStyles(hlStyles);
 	if(cursor.GetCount())
 		sel <<= cursor;
 	else
@@ -286,7 +286,7 @@ void LayDes::VisGen()
 {
 	if(IsNull(currentlayout))
 		return;
-	VisGenDlg dlg(CurrentLayout(), cursor);
+	VisGenDlg dlg(CurrentLayout(), cursor, hlStyles);
 	if(dlg.Run() == IDOK)
 		WriteClipboardText(~dlg.view);
 }


### PR DESCRIPTION
In the current implementation Layout Designer do not have access to code editor highlighting style. It means that VisGen uses the default scheme. It is not problem when user uses default highlighting, but when there is a customization for example with dark colors VisGen overrides global settings on dialog close.

The issue is described in this forum [thread](https://www.ultimatepp.org/forums/index.php?t=msg&goto=59282&#msg_59282).

Since, I added new file to ide/LayDes there is a need for makefile regeneration.