### PR TITLE
Tabbar::GetTargetTab() fix:  bounds-checking implemented (crash fix).

### DIFF
--- a/uppsrc/TabBar/TabBar.cpp
+++ b/uppsrc/TabBar/TabBar.cpp
@@ -2234,6 +2234,10 @@ int TabBar::GetTargetTab(Point p)
 
 	int f = GetFirst();
 	int l = GetLast();
+	int n = tabs.GetCount();
+
+	if(f < 0 || f >= n || l < 0 || l >= n)
+		return -1;
 	
 	if(tabs[f].visible && p.x < tabs[f].pos.x + tabs[f].size.cx / 2)
 		return f;
@@ -2251,9 +2255,9 @@ int TabBar::GetTargetTab(Point p)
 		l = FindStackHead(tabs[l].stack);
 		
 	if(t == l)
-		t = tabs.GetCount();
+		t = n;
 	else
-	 	t = GetNext(t);
+		t = GetNext(t);
 
 	return t;
 }


### PR DESCRIPTION
Fixes a crash due to out-of-bounds access (access violation), when dragging stuff over an empty tabbar.
Original report: https://www.ultimatepp.org/forums/index.php?t=msg&th=11990&goto=59424&#msg_59424