### PR TITLE
remove bitwise or with booleans warnings by changing to plus

### DIFF
--- a/uppsrc/CtrlCore/GtkEvent.cpp
+++ b/uppsrc/CtrlCore/GtkEvent.cpp
@@ -638,7 +638,7 @@ void Ctrl::Proc()
 			if(x)
 				kv = x->b;
 			else {
-				if(GetCtrl() | GetAlt()) {// fix Ctrl+Shift+1 etc...
+				if(GetCtrl() + GetAlt()) {// fix Ctrl+Shift+1 etc...
 					static VectorMap<int, int> hwkv;
 					ONCELOCK {
 						for(int k : { GDKEY(0), GDKEY(1), GDKEY(2), GDKEY(3), GDKEY(4),

--- a/uppsrc/CtrlCore/GtkEvent.cpp
+++ b/uppsrc/CtrlCore/GtkEvent.cpp
@@ -638,7 +638,7 @@ void Ctrl::Proc()
 			if(x)
 				kv = x->b;
 			else {
-				if(GetCtrl() + GetAlt()) {// fix Ctrl+Shift+1 etc...
+				if(GetCtrl() || GetAlt()) {// fix Ctrl+Shift+1 etc...
 					static VectorMap<int, int> hwkv;
 					ONCELOCK {
 						for(int k : { GDKEY(0), GDKEY(1), GDKEY(2), GDKEY(3), GDKEY(4),

--- a/uppsrc/CtrlLib/ScrollBar.cpp
+++ b/uppsrc/CtrlLib/ScrollBar.cpp
@@ -687,8 +687,7 @@ void ScrollBars::Set(Point pos, Size page, Size total) {
 }
 
 bool ScrollBars::Set(int _x, int _y) {
-	bool b = x.Set(_x) | y.Set(_y);
-	return b;
+	return x.Set(_x) + y.Set(_y);
 }
 
 bool ScrollBars::Set(Point pos) {
@@ -714,11 +713,11 @@ void ScrollBars::SetTotal(Size total) {
 }
 
 bool ScrollBars::ScrollInto(Point pos, Size linesize) {
-	return x.ScrollInto(pos.x, linesize.cx) | y.ScrollInto(pos.y, linesize.cy);
+	return x.ScrollInto(pos.x, linesize.cx) + y.ScrollInto(pos.y, linesize.cy);
 }
 
 bool ScrollBars::ScrollInto(Point pos) {
-	return x.ScrollInto(pos.x) | y.ScrollInto(pos.y);
+	return x.ScrollInto(pos.x) + y.ScrollInto(pos.y);
 }
 
 ScrollBars& ScrollBars::SetLine(int linex, int liney) {


### PR DESCRIPTION
bool(bool(a) | bool(b)) == bool(bool(a) + bool(b)), but without warning suggesting casting to integer.