### PR TITLE
Fix SourceToObjName to handle .. in paths

### DIFF
--- a/uppsrc/ide/Builders/CppBuilder.cpp
+++ b/uppsrc/ide/Builders/CppBuilder.cpp
@@ -547,15 +547,23 @@ bool CppBuilder::HasAnyDebug() const
 	return HasFlag("DEBUG") || HasFlag("DEBUG_MINIMAL") || HasFlag("DEBUG_FULL");
 }
 
-String SourceToObjName(const String& package, const String& srcfile_)
+String SourceToObjName(const String& /* package */, const String& srcfile_)
 {
 	String srcfile = srcfile_;
 	srcfile.TrimEnd(".cpp");
-	int q = GetFileFolder(PackagePath(package)).GetCount() + 1;
-	if(q >= srcfile.GetCount())
-		return GetFileTitle(srcfile);
 	String r;
-	for(const char *s = ~srcfile + q; *s; s++)
-		r.Cat(findarg(*s, '/', '\\') >= 0 ? '_' : *s);
+	for(const char *s = ~srcfile; *s; s++)
+	{
+		if(*s == '/' || *s == '\\')
+			r.Cat('_');
+		else if(*s == '.' && *(s+1) == '.')
+		{
+			r.Cat('_');
+			r.Cat('_');
+			s++;
+		}
+		else
+			r.Cat(*s);
+	}
 	return r;
 }


### PR DESCRIPTION
Fix SourceToObjName to handle .. in paths - needed for some packages using import.ext

Example of include.ext requiring this patch:

`
files  ../_OCC_/FSD/*.c*;
files  ../_OCC_/OSD/*.c*;
files  ../_OCC_/Plugin/*.c*;
files  ../_OCC_/Quantity/*.c*;
files  ../_OCC_/Resource/*.c*;
files  ../_OCC_/Standard/*.c*;
files  ../_OCC_/StdFail/*.c*;
files  ../_OCC_/Storage/*.c*;
files  ../_OCC_/TColStd/*.c*;
files  ../_OCC_/TCollection/*.c*;
files  ../_OCC_/TShort/*.c*;
files  ../_OCC_/Units/*.c*;
files  ../_OCC_/UnitsAPI/*.c*;
files  ../_OCC_/UnitsMethods/*.c*;
files  ../_OCC_/NCollection/*.c*;
files  ../_OCC_/Message/*.c*;

includes ../_OCC_/*.h*, ../_OCC_/*.g*;

`