### PR TITLE
Add forward declaration of DstSrcOp to ImageOp.h

### DIFF
--- a/uppsrc/Draw/ImageOp.h
+++ b/uppsrc/Draw/ImageOp.h
@@ -12,6 +12,8 @@ Image WithResolution(const Image& m, int res);
 Image WithResolution(const Image& m, const Image& res);
 
 void  ScanOpaque(Image& m);
+void DstSrcOp(ImageBuffer& dest, Point p, const Image& src, const Rect& srect,
+                           void (*op)(RGBA *t, const RGBA *s, int n));
 
 void Over(ImageBuffer& dest, Point p, const Image& src, const Rect& srect);
 void Over(Image& dest, const Image& src);


### PR DESCRIPTION
DstSrcOp is a useful function that is extern but has no declaration in any header.