### PR TITLE
Console wasn't opening by default for FreeBSD 

### DIFF
--- a/uppsrc/ide/Core/Host.cpp
+++ b/uppsrc/ide/Core/Host.cpp
@@ -223,6 +223,16 @@ void Host::Launch(const char *_cmdline, bool console)
 		cmdline = "/usr/bin/open " + script;
 #else
 	String lc;
+	
+	#ifdef PLATFORM_BSD
+	static const char *term[] = {
+		"/usr/local/bin/mate-terminal -x",
+		"/usr/local/bin/gnome-terminal --window -x",
+		"/usr/local/bin/konsole -e",
+		"/usr/local/bin/lxterminal -e",
+		"/usr/local/bin/xterm -e",
+	};
+	#else
 	static const char *term[] = {
 		"/usr/bin/mate-terminal -x",
 		"/usr/bin/gnome-terminal --window -x",
@@ -230,6 +240,7 @@ void Host::Launch(const char *_cmdline, bool console)
 		"/usr/bin/lxterminal -e",
 		"/usr/bin/xterm -e",
 	};
+	#endif
 	int ii = 0;
 	for(;;) { // If (pre)defined terminal emulator is not available, try to find one
 		int c = HostConsole.FindFirstOf(" ");

--- a/uppsrc/ide/Setup.cpp
+++ b/uppsrc/ide/Setup.cpp
@@ -321,11 +321,19 @@ void Ide::SetupFormat() {
 	ide.mate.Hide();
 	ide.lxde.Hide();
 #else
+	#ifdef PLATFORM_BSD
+	ide.kde <<= callback2(SetConsole, &ide.console, "/usr/local/bin/konsole -e");
+	ide.gnome <<= callback2(SetConsole, &ide.console, "/usr/local/bin/gnome-terminal -x");
+	ide.mate <<= callback2(SetConsole, &ide.console, "/usr/local/bin/mate-terminal -x");
+	ide.lxde <<= callback2(SetConsole, &ide.console, "/usr/local/bin/lxterminal -e");
+	ide.xterm <<= callback2(SetConsole, &ide.console, "/usr/local/bin/xterm -e");
+	#else
 	ide.kde <<= callback2(SetConsole, &ide.console, "/usr/bin/konsole -e");
 	ide.gnome <<= callback2(SetConsole, &ide.console, "/usr/bin/gnome-terminal -x");
 	ide.mate <<= callback2(SetConsole, &ide.console, "/usr/bin/mate-terminal -x");
 	ide.lxde <<= callback2(SetConsole, &ide.console, "/usr/bin/lxterminal -e");
 	ide.xterm <<= callback2(SetConsole, &ide.console, "/usr/bin/xterm -e");
+	#endif
 #endif
 
 	FontSelectManager ed, vf, con, f1, f2, tf, gui;


### PR DESCRIPTION
Console apps are stored in /usr/local/bin by default on BSD instead of /usr/bin because they're considered third party apps.