### PR TITLE
AutoTest does not build on windows due to missing 'setenv'

### DIFF
--- a/autotest/SetEnvVar/SetEnvVar.cpp
+++ b/autotest/SetEnvVar/SetEnvVar.cpp
@@ -1,0 +1,22 @@
+#include <Core/Core.h>
+
+using namespace Upp;
+
+CONSOLE_APP_MAIN
+{
+	String cmd, out;
+	
+#ifdef PLATFORM_WIN32
+	cmd = "cmd /C \"echo 1 %FOOBAR% 2\"";
+	ASSERT(Sys(cmd) == "1 %FOOBAR% 2\r\n");
+	SetEnv("FOOBAR","BAZ");
+	ASSERT(Sys(cmd) == "1 BAZ 2\r\n");
+#else
+	cmd = "echo \"1 $FOOBAR 2\"";
+	ASSERT(Sys(cmd) == "1  2\n");
+	SetEnv("FOOBAR","BAZ");
+	ASSERT(Sys(cmd) == "1 BAZ 2\n");
+#endif
+	
+	ASSERT(GetEnv("FOOBAR") == "BAZ");
+}

--- a/autotest/SetEnvVar/SetEnvVar.upp
+++ b/autotest/SetEnvVar/SetEnvVar.upp
@@ -1,0 +1,9 @@
+uses
+	Core;
+
+file
+	SetEnvVar.cpp;
+
+mainconfig
+	"" = "";
+

--- a/uppbox/AutoTest/AutoTest.cpp
+++ b/uppbox/AutoTest/AutoTest.cpp
@@ -63,8 +63,8 @@ void Do(const char *nest, const char *bm, bool release, bool test)
 				if(test) {
 					Tested++;
 					LocalProcess p;
-					setenv("UPP_MAIN__", ff.GetPath(), 1);
-					setenv("UPP_ASSEMBLY__", GetFileFolder(ff.GetPath()), 1);
+					SetEnv("UPP_MAIN__", ff.GetPath());
+					SetEnv("UPP_ASSEMBLY__", GetFileFolder(ff.GetPath()));
 					if(!p.Start(exe)) {
 						Cout() << "FAILED TO RUN\n";
 						infolog << ", FAILED TO RUN";

--- a/uppsrc/Core/App.cpp
+++ b/uppsrc/Core/App.cpp
@@ -69,6 +69,15 @@ String GetEnv(const char *id)
 	return WString(_wgetenv(ToSystemCharsetW(id))).ToString();
 }
 
+bool SetEnv(const char *name, const char *value)
+{
+	String env;
+	env << name << "=" << value;
+	auto wenv = ToUtf16(env);
+	wenv.Add(wchar_t(0));
+	return _wputenv(wenv.begin()) == 0;
+}
+
 String GetExeFilePath()
 {
 	return GetModuleFileName();
@@ -81,6 +90,11 @@ String GetExeFilePath()
 String GetEnv(const char *id)
 {
 	return FromSystemCharset(getenv(id));
+}
+
+bool SetEnv(const char *name, const char *value)
+{
+	return setenv(name, value, 1) == 0;
 }
 
 static void sSetArgv0__(const char *title)

--- a/uppsrc/Core/App.h
+++ b/uppsrc/Core/App.h
@@ -1,4 +1,5 @@
 String  GetEnv(const char *id);
+bool SetEnv(const char *name, const char *value);
 
 String  GetExeFilePath();
 String  GetExeTitle();


### PR DESCRIPTION
This PR adds a new SetEnv function to match the GetEnv which can then be used in AutoTest
Test was a bit fiddly, feedback appreciated.