### PR TITLE
Editor overwrite mode fixes

### DIFF
--- a/uppsrc/CodeEditor/CLogic.cpp
+++ b/uppsrc/CodeEditor/CLogic.cpp
@@ -129,7 +129,7 @@ void CSyntax::IndentInsert0(CodeEditor& e, int chr, int count, bool reformat)
 	int cl = e.GetCursorLine();
 	WString l = e.GetWLine(cl);
 	if(chr != '{' && chr != '}' || count > 1) {
-		e.InsertChar(chr, 1, true);
+		e.InsertChar(chr, count, true);
 		return;
 	}
 	const wchar *s;

--- a/uppsrc/CodeEditor/CodeEditor.cpp
+++ b/uppsrc/CodeEditor/CodeEditor.cpp
@@ -343,7 +343,7 @@ void CodeEditor::IndentInsert(int chr, int count) {
 	if(s)
 		s->IndentInsert(*this, chr, count);
 	else
-		InsertChar(chr, count);
+		InsertChar(chr, count, true);
 }
 
 void CodeEditor::Make(Event<String&> op)

--- a/uppsrc/CodeEditor/PythonSyntax.cpp
+++ b/uppsrc/CodeEditor/PythonSyntax.cpp
@@ -80,7 +80,7 @@ void PythonSyntax::IndentInsert(CodeEditor& editor, int chr, int count)
 		}
 	}
 	if(count > 0)
-		editor.InsertChar(chr, count);
+		editor.InsertChar(chr, count, true);
 }
 
 bool PythonSyntax::LineHasColon(const WString& line)

--- a/uppsrc/CodeEditor/Syntax.cpp
+++ b/uppsrc/CodeEditor/Syntax.cpp
@@ -16,7 +16,7 @@ void EditorSyntax::Serialize(Stream& s)
 
 void EditorSyntax::IndentInsert(CodeEditor& editor, int chr, int count)
 {
-	editor.InsertChar(chr, count);
+	editor.InsertChar(chr, count, true);
 }
 
 bool EditorSyntax::CheckBrackets(CodeEditor& e, int64& bpos0, int64& bpos)

--- a/uppsrc/CodeEditor/TagSyntax.cpp
+++ b/uppsrc/CodeEditor/TagSyntax.cpp
@@ -276,7 +276,7 @@ void TagSyntax::IndentInsert(CodeEditor& editor, int chr, int count)
 	if(status == SCRIPT)
 		script.IndentInsert(editor, chr, count);
 	else
-		editor.InsertChar(chr, count);
+		editor.InsertChar(chr, count, true);
 }
 
 bool TagSyntax::CheckBrackets(CodeEditor& e, int64& bpos0, int64& bpos)


### PR DESCRIPTION
Overwrite worked only in CSyntax files, failed in txt, etc..

second commit: seems to me there was ignored `count` argument in CSyntax::IndentInsert0 - I'm not sure how test this and where `count > 1` can emerge, but seems to me like bug.

Please review, I don't understand all possible code paths how these can be triggered, and why the `canoverwrite` argument even was added in the first place (as InsertChar itself does ignore overwrite for certain characters like newline), so I tried my best guess where the canoverwrite change should be harmless, but I have no deep understanding.