### PR TITLE
CoWork warnings with clang/C++17 (std::result_of)

### DIFF
--- a/uppsrc/Core/CoWork.h
+++ b/uppsrc/Core/CoWork.h
@@ -220,7 +220,7 @@ public:
 
 template< class Function, class... Args>
 AsyncWork<
-#ifdef CPP_20
+#ifdef CPP_17
 	std::invoke_result_t<Function, Args...>
 #else
 	typename std::result_of<
@@ -232,7 +232,7 @@ AsyncWork<
 Async(Function&& f, Args&&... args)
 {
 	AsyncWork<
-#ifdef CPP_20
+#ifdef CPP_17
 		std::invoke_result_t<Function, Args...>
 #else
 		typename std::result_of<


### PR DESCRIPTION
std::result_of is deprecated in c++17 not 20