### PR TITLE
svg painter: update current in LineOp

### DIFF
--- a/uppsrc/Painter/SvgBounds.cpp
+++ b/uppsrc/Painter/SvgBounds.cpp
@@ -28,7 +28,7 @@ void BoundsPainter::LineOp(const Pointf& p, bool rel)
 	sw.Line(p, rel);
 	Bounds(current);
 	Bounds(p);
-	ccontrol = qcontrol = p;
+	qcontrol = ccontrol = current = p;
 }
 
 void QuadraticMinMax(double p1, double p2, double p3, double& l, double& h) {


### PR DESCRIPTION
An SVG path with d="M x y L z t A ..." draws wrong arcs, because the arc starting point is (x, y) and not (z, t). There was a missing update of current within BoundsPainter::LineOp().