### PR TITLE
Ide: Displaying progress while cloning UppHub repositories

### DIFF
--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -547,7 +547,7 @@ void UppHubDlg::Install(const Index<String>& ii_)
 			if(n) {
 				String dir = GetHubDir() + '/' + n->name;
 				if(!DirectoryExists(dir)) {
-					String cmd = "git clone ";
+					String cmd = "git clone --progress ";
 					if(n->branch.GetCount())
 						cmd << "-b " + n->branch << ' ';
 					cmd << n->repo;


### PR DESCRIPTION
RIght now there is no information about progress while cloning UppHub repertoires. It is problematic when you need to clone repository that is big (1GB+) for example BEMRosseta. To overcome this issue --progress parameter can be added to git clone command.

This PR addresses above issue.