### PR TITLE
Ide: Licenses should be copied on demand

### DIFF
--- a/uppsrc/ide/ide.lay
+++ b/uppsrc/ide/ide.lay
@@ -487,6 +487,7 @@ END_LAYOUT
 LAYOUT(StatLayout, 732, 552)
 	ITEM(Upp::RichTextView, stat, HSizePosZ(8, 8).VSizePosZ(8, 40))
 	ITEM(Upp::Button, ok, SetLabel(t_("OK")).RightPosZ(8, 64).BottomPosZ(8, 24))
+	ITEM(Upp::Button, copy, SetLabel(t_("Copy to clipboard")).LeftPosZ(8, 104).BottomPosZ(8, 24))
 END_LAYOUT
 
 LAYOUT(SetupFontLayout, 528, 312)

--- a/uppsrc/ide/idetool.cpp
+++ b/uppsrc/ide/idetool.cpp
@@ -183,11 +183,13 @@ void sPut(String& qtf, ArrayMap<String, FileStat>& pfs, ArrayMap<String, FileSta
 void ShowQTF(const String& qtf, const char *title)
 {
 	RichText txt = ParseQTF(qtf);
-	ClearClipboard();
-	AppendClipboard(ParseQTF(qtf));
 
 	WithStatLayout<TopWindow> dlg;
 	CtrlLayoutOK(dlg, title);
+	dlg.copy.WhenAction = [=] {
+		AppendClipboard(ParseQTF(qtf));
+		PromptOK("The whole content of the text view has been successfully copied to cliboard!");
+	};
 	dlg.stat = qtf;
 	dlg.Sizeable().Zoomable();
 	dlg.Run();


### PR DESCRIPTION
Some time ago, one of our users complained about the issue that whenever he opened the "Statistics" or "Project Licenses" dialog, the clipboard content had been replaced. This operation should only be executed on demand. The PR addresses this issue by adding the "Copy to clipboard" option to the Stat dialog.