### PR TITLE
core.upt should have an option for ssl

### DIFF
--- a/uppsrc/Core/core.upt
+++ b/uppsrc/Core/core.upt
@@ -2,6 +2,7 @@ template "U++ Core console project" main;
 
 option "Create header" header;
 option "Commandline loop" cmdline;
+option "Add SSL support" ssl;
 
 @@<:PACKAGE:>.h
 ??header
@@ -25,7 +26,9 @@ CONSOLE_APP_MAIN
 	}<:.:>
 }
 @@<:PACKAGE:>.upp
-uses Core;
+uses
+	Core<:?ssl:>,<:/:>;<:.:>
+	<:?ssl:>Core/SSL;<:.:>
 
 file<:?header:>
 	<:PACKAGE:>.h,<:.:>


### PR DESCRIPTION
SSL is requiered for all modern network application. For example today most of the http resources are available through https not http. When creating core package there should be an easy way to add SSL support to it