### PR TITLE
Ide: Git - GetCredentials fix (now returns true on success)

### DIFF
--- a/uppsrc/ide/Credentials.cpp
+++ b/uppsrc/ide/Credentials.cpp
@@ -135,6 +135,7 @@ bool GetCredentials(const String& url, const String& dir, String& username, Stri
 				password = c.password;
 			}
 		}
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Ide::GetCretentials returns only false, which causes git commits and pushes to fail.
This pull request aims to fix the issue.