### PR TITLE
UMK doesn't work for build method localized in relative paths

### DIFF
--- a/uppsrc/umk/umake.cpp
+++ b/uppsrc/umk/umake.cpp
@@ -272,7 +272,7 @@ CONSOLE_APP_MAIN
 			PutVerbose("Target override: " << ide.debug.target);
 		}
 
-		ide.method = m;
+		ide.method = bp;
 
 		if(ccfile) {
 			ide.SaveCCJ(GetFileDirectory(PackagePath(ide.main)) + "compile_commands.json", false);


### PR DESCRIPTION
It looks like UMK ignores the code responsible for normalization of build method localizes in line 260 and use raw parameter. It looks like it was done by omission.

When I ran following command:
```
klugier@X470Pro:Dokumenty/SimpleTerminal ‹main*›$ 3p/umk/umk app/,3p/uppsrc SimpleTerminal 3p/umk/CLANG.bm -brv +GUI,SHARED build/SimpleTerminal  
Config directory: /home/klugier/.config/u++
Inline assembly: /home/klugier/Dokumenty/SimpleTerminal/app;/home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc
Output directory: /home/klugier/.cache/upp.out
Main package: /home/klugier/Dokumenty/SimpleTerminal/app/SimpleTerminal/SimpleTerminal.upp
Build flags: GUI SHARED
Build method: /home/klugier/Dokumenty/SimpleTerminal/3p/umk/CLANG.bm
Target override: /home/klugier/Dokumenty/SimpleTerminal/build/SimpleTerminal
Saving 

----- CtrlLib ( GUI SHARED GCC BLITZ POSIX LINUX ) (1 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/CtrlLib
Invalid build method 3p/umk/CLANG.bm ().
```
I have invalid build method. After fix it is:
```
klugier@X470Pro:Dokumenty/SimpleTerminal ‹main*›$ 3p/umk/umk app/,3p/uppsrc SimpleTerminal 3p/umk/CLANG.bm -brv +GUI,SHARED build/SimpleTerminal
Config directory: /home/klugier/.config/u++
Inline assembly: /home/klugier/Dokumenty/SimpleTerminal/app;/home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc
Output directory: /home/klugier/.cache/upp.out
Main package: /home/klugier/Dokumenty/SimpleTerminal/app/SimpleTerminal/SimpleTerminal.upp
Build flags: GUI SHARED
Build method: /home/klugier/Dokumenty/SimpleTerminal/3p/umk/CLANG.bm
Target override: /home/klugier/Dokumenty/SimpleTerminal/build/SimpleTerminal
Saving 

----- CtrlLib ( GUI SHARED GCC BLITZ POSIX LINUX ) (1 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/CtrlLib
----- CtrlCore ( GUI SHARED GCC BLITZ POSIX LINUX ) (2 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/CtrlCore
----- PdfDraw ( GUI SHARED GCC BLITZ POSIX LINUX ) (3 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/PdfDraw
----- Draw ( GUI SHARED GCC BLITZ POSIX LINUX ) (4 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/Draw
----- plugin/bmp ( GUI SHARED GCC BLITZ POSIX LINUX ) (5 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/plugin/bmp
----- RichText ( GUI SHARED GCC BLITZ POSIX LINUX ) (6 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/RichText
----- Painter ( GUI SHARED GCC BLITZ POSIX LINUX ) (7 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/Painter
----- Core ( GUI SHARED GCC BLITZ POSIX LINUX ) (8 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/Core
----- plugin/png ( GUI SHARED GCC BLITZ POSIX LINUX ) (9 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/3p/uppsrc/plugin/png
----- SimpleTerminal ( GUI SHARED MAIN GCC BLITZ POSIX LINUX ) (10 / 10)
cd /home/klugier/Dokumenty/SimpleTerminal/app/SimpleTerminal
/home/klugier/Dokumenty/SimpleTerminal/build/SimpleTerminal (2670808 B) is up to date.

OK. (0:00.18)
```

