### PR TITLE
UMK auto Upphub download doesn't work when there are more than one UppHub package

### DIFF
--- a/uppsrc/umk/UppHub.cpp
+++ b/uppsrc/umk/UppHub.cpp
@@ -181,7 +181,7 @@ bool UppHubAuto(const String& main)
 				if(missing.Find(p) >= 0)
 					found.FindAdd(n.name);
 
-		if(found.GetCount() == missing.GetCount() && missing != pmissing) {
+		if(found.GetCount() == missing.GetCount() || missing != pmissing) {
 			dlg.Install(found);
 			pmissing = clone(missing);
 			continue;


### PR DESCRIPTION
I have a problem with compiling following project with UMK -h option:
```
uses
	CtrlLib,
	Terminal,
	PtyProcess;

file
	main.cpp;

mainconfig
	"" = "GUI";

```
Please keep in mind that there are two packages from UppHub "Terminal" and "PtyProcess". When I declare only one of them UMK works when expected, when there are two of them then there is a problem.

I found a solution in line umk/UppHub.cpp line 184. You just need to chagne && to || and then everything works as expected. Please verify since I am not very sure about this change.
