### PR TITLE
DLOGs and DDUMPs are renamed in X11Wnd.cpp for successfull NOGTK builds.

### DIFF
--- a/uppsrc/CtrlCore/X11Wnd.cpp
+++ b/uppsrc/CtrlCore/X11Wnd.cpp
@@ -443,7 +443,7 @@ void Ctrl::EventLoop(Ctrl *ctrl)
 		while(IsWaitingEvent()) {
 			LTIMING("XNextEvent");
 			XNextEvent(Xdisplay, &event);
-			DDUMP(event.type);
+			LDUMP(event.type);
 			ProcessEvent(&event);
 		}
 		TimerAndPaint();
@@ -930,18 +930,18 @@ Window Ctrl::GetXServerFocusWindow()
 	GuiLock __;
 	Window w;
 	int    dummy;
-	DLOG("XGetInputFocus");
+	LLOG("XGetInputFocus");
 	XGetInputFocus(Xdisplay, &w, &dummy);
 	return w;
 }
 
 void Ctrl::FocusSync()
 {
-	DLOG("FocusSync");
+	LLOG("FocusSync");
 	GuiLock __;
 	Window fw = GetXServerFocusWindow();
 	if(fw != focusWindow) {
-		DLOG("FocusSync to " << FormatIntHex(fw));
+		LLOG("FocusSync to " << FormatIntHex(fw));
 		if(fw) {
 			int q = Xwindow().Find(fw);
 			if(q >= 0) {


### PR DESCRIPTION
X11 (NOGTK) release builds fail due to the remaining DDUMPs and DLOGs in the code. They are renamed as LDUMP and LLOG macros.