### PR TITLE
Added verification and error handling for GCC builder when compiler doesn't exist

### DIFF
--- a/uppsrc/ide/Builders/Builders.h
+++ b/uppsrc/ide/Builders/Builders.h
@@ -77,6 +77,7 @@ struct GccBuilder : CppBuilder {
 	virtual bool   Preprocess(const String& package, const String& file, const String& target, bool asmout);
 
 	String CompilerName() const;
+	bool   IsCompilerPresent() const;
 	String CmdLine(const String& package, const Package& pkg);
 	void BinaryToObject(String objfile, CParser& binscript, String basedir, const String& package, const Package& pkg);
 	void   CocoaAppBundle();

--- a/uppsrc/ide/Builders/GccBuilder.cpp
+++ b/uppsrc/ide/Builders/GccBuilder.cpp
@@ -11,6 +11,12 @@ String GccBuilder::CompilerName() const
 	return "c++";
 }
 
+bool GccBuilder::IsCompilerPresent() const
+{
+	String output;
+	return HostSys(CompilerName() + " --version", output) == 0;
+}
+
 String GccBuilder::CmdLine(const String& package, const Package& pkg)
 {
 	String cc = CompilerName();
@@ -49,6 +55,15 @@ bool GccBuilder::BuildPackage(const String& package, Vector<String>& linkfile, V
 		else
 			target = target + ".app/Contents/MacOS/" + GetFileName(target);
 		RealizePath(target);
+	}
+
+	if(!IsCompilerPresent()) {
+		PutConsole(
+			Format("Error: Failed to find the '%s' compiler executable! Make sure the compiler "
+		           "is installed and is present in the executables path.",
+		           CompilerName()));
+		IdeConsoleEndGroup();
+		return false;
 	}
 
 	SaveBuildInfo(package);


### PR DESCRIPTION
In the current GCC build algorithm, there is no clear indicator that the compiler executable doesn't exist. For example, let's assume that I typed "g+++" instead of "g++." In this case, there will be output on the compilation, but details about why it failed won't be present.

To mitigate this issue, there is a need to add a simple check at the beginning of the GccBuilder::BuildPackage method.

Output with change:
```
Saving 
----- ide/Builders ( GCC POSIX LINUX ) (1 / 12)
Error: Failed to find the 'aarch64-linux-gnu-c++a' compiler executable! Make sure the compiler is installed and is present in the executables path.

There were errors. (0:00.00)
```

Output before:
```
Saving 
----- ide/Builders ( GCC POSIX LINUX ) (1 / 12)
CppBuilder.cpp
MakeFile.cpp
CCJ.cpp
GccBuilder.cpp
MscBuilder.cpp
JavaBuilder.cpp
ScriptBuilder.cpp
Cocoa.cpp
AndroidProject.cpp
AndroidApplicationMakeFile.cpp
AndroidMakeFile.cpp
AndroidModuleMakeFile.cpp
AndroidBuilder.cpp
AndroidBuilderCommands.cpp
AndroidBuilderUtils.cpp
AndroidModuleMakeFileBuilder.cpp
Blitz.cpp
Build.cpp
Install.cpp
BuilderUtils.cpp

There were errors. (0:00.04)
```
In the above output the root cause is unknown.