### PR TITLE
CircleCI for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       NUMBER_OF_CPUS: 4
     steps:
       - checkout
+      - run: brew install openssl
+      - run: ls -l /opt/homebrew/lib
+      - run: ls -l /opt/homebrew/Cellar
       - run: ./configure
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
       - run: ./umk ./uppsrc ide CLANG -brs ./theide

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
     steps:
       - checkout
       - run: brew install openssl
-      - run: ls -l /opt/homebrew/lib
-      - run: ls -l /opt/homebrew/Cellar
+      - run: brew list openssl
+      - run: ls -l /opt/homebrew
       - run: ./configure
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
       - run: ./umk ./uppsrc ide CLANG -brs ./theide

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run: ./configure
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
-      - run: umk ./uppsrc ide CLANG -brs ./theide
+      - run: ./umk ./uppsrc ide CLANG -brs ./theide
 
 workflows:
   build-linux:
@@ -33,4 +33,3 @@ workflows:
   build-mac:
     jobs:
       - build-mac
-  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 jobs:
-  build:
+  build-linux:
     docker:
-      - image: cimg/base:2023.12
+      - image: cimg/base:2024.01
     resource_class: large
     environment:
       NUMBER_OF_CPUS: 4
@@ -11,5 +11,26 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - run: sudo apt-get install g++ clang git make libgtk-3-dev libnotify-dev libbz2-dev libssl-dev xdotool
+      - run: ./configure
       - run: make -f Makefile -j ${NUMBER_OF_CPUS}
-      - run: make -f umkMakefile.in -j ${NUMBER_OF_CPUS}
+      - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
+  build-mac:
+    macos:
+      xcode: 15.1.0
+    environment:
+      NUMBER_OF_CPUS: 4
+    steps:
+      - checkout
+      - run: ./configure
+      - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
+      - run: umk ./uppsrc ide CLANG -brs ./theide
+
+workflows:
+  build-linux:
+    jobs:
+      - build-linux
+  
+  build-mac:
+    jobs:
+      - build-mac
+  

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,8 @@ jobs:
       - checkout
       - run: brew install openssl
       - run: brew list openssl
-      - run: ls -l /opt/homebrew
+      - run: ls -l /usr/local/
+      - run: ls -l /usr/local/lib
       - run: ./configure
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
       - run: ./umk ./uppsrc ide CLANG -brs ./theide

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ jobs:
       NUMBER_OF_CPUS: 4
     steps:
       - checkout
-      - run: brew install openssl
-      - run: brew list openssl
-      - run: ls -l /usr/local/
-      - run: ls -l /usr/local/lib
       - run: ./configure
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
       - run: ./umk ./uppsrc ide CLANG -brs ./theide

--- a/configure_makefile
+++ b/configure_makefile
@@ -59,6 +59,7 @@ fi
 
 if [[ "$uname" == 'Darwin' ]]; then
 	echo Configuring $1 for MacOS
+	sed -i.bak 's/-DflagPOSIX -DflagLINUX/-DflagPOSIX -DflagBSD -DflagOSX/' $1
 	sed -i.bak 's/-Wl,--gc-sections $(LINKOPTIONS)/$(LINKOPTIONS)/' $1
 	sed -i.bak 's/\`pkg-config --cflags .*\`/ /' $1
 	sed -i.bak 's/\`pkg-config --libs .*\`/ /' $1
@@ -67,6 +68,5 @@ if [[ "$uname" == 'Darwin' ]]; then
 	sed -i.bak 's/-Wl,-s/ /' $1
 	sed -i.bak 's/-Wl,--start-group/ /' $1
 	sed -i.bak 's/-Wl,--end-group/ /' $1
-	sed -i.bak 's/-DflagLINUX/-DflagBSD -DflagOSX/' umkMakefile
 	sed -i.bak 's/$(LIBPATH) -Wl,-O,2 $(LDFLAGS)/$(LIBPATH) $(LDFLAGS)/' $1
 fi

--- a/uppsrc/ide/Builders/Install.cpp
+++ b/uppsrc/ide/Builders/Install.cpp
@@ -160,8 +160,8 @@ void CreateBuildMethods()
 			bm.Replace(var, h);
 		};
 		
-		Path("$INCLUDE$", "/opt/local/include;/usr/include;/opt/homebrew/include;/opt/homebrew/opt/openssl/include");
-		Path("$LIB$", "/opt/local/lib;/usr/lib;/opt/homebrew/lib;/opt/homebrew/opt/openssl/lib");
+		Path("$INCLUDE$", "/opt/local/include;/usr/include;/usr/local/include;/opt/homebrew/include;/opt/homebrew/opt/openssl/include");
+		Path("$LIB$", "/opt/local/lib;/usr/lib;/usr/local/lib;/opt/homebrew/lib;/opt/homebrew/opt/openssl/lib");
 		
 		String common;
 	#ifdef CPU_ARM


### PR DESCRIPTION
Additional CircleCI run for validating macos build. Moreover, it looks like openssl is store in diffrent path on build machines "/usr/local/lib;". Currently, we don't look in this path for libraries and include files. This PR also address this issue. This problem might be related to this issue raised on our forum, so it is highly recommended to apply.

Currently free version of CircleCI addressed to open source dev is on x86_64. From May 2024 they will change it to ARM and M1.

Issues:
- https://www.ultimatepp.org/forums/index.php?t=msg&goto=60416&#msg_60416