### PR TITLE
CtrlCore: Horizontal mouse wheel support using MouseWheelHor()

### DIFF
--- a/uppsrc/CtrlCore/CtrlCore.h
+++ b/uppsrc/CtrlCore/CtrlCore.h
@@ -882,6 +882,7 @@ public:
 		MOUSELEAVE    = 0x30,
 		CURSORIMAGE   = 0x40,
 		MOUSEWHEEL    = 0x50,
+		MOUSEHWHEEL   = 0x60,
 
 		DOWN          = 0x80,
 		UP            = 0x90,
@@ -987,6 +988,7 @@ public:
 	virtual void   MiddleHold(Point p, dword keyflags);
 	virtual void   MiddleUp(Point p, dword keyflags);
 	virtual void   MouseWheel(Point p, int zdelta, dword keyflags);
+	virtual void   MouseWheelHor(Point p, int zdelta, dword keyflags);
 	virtual void   MouseLeave();
 	
 	virtual void   Pen(Point p, const PenInfo& pen, dword keyflags);

--- a/uppsrc/CtrlCore/CtrlMouse.cpp
+++ b/uppsrc/CtrlCore/CtrlMouse.cpp
@@ -95,7 +95,7 @@ Image Ctrl::MouseEvent0(int event, Point p, int zdelta, dword keyflags)
 	sPropagated = false;
 	Image m = this_ ? MouseEvent(event, p, zdelta, keyflags) : Image();
 	Ctrl *parent = this_ ? this_->GetParent() : NULL;
-	if(event == MOUSEWHEEL && !sPropagated && this_ && parent)
+	if(((event == MOUSEWHEEL)||(event == MOUSEHWHEEL)) && !sPropagated && this_ && parent)
 		parent->ChildMouseEvent(this, event, p, zdelta, keyflags);
 	sPropagated = pb;
 	return m;
@@ -111,7 +111,7 @@ Image Ctrl::MouseEventH(int event, Point p, int zdelta, dword keyflags)
 	if(this_)
 		LogMouseEvent(NULL, this, event, p, zdelta, keyflags);
 	Ctrl *parent = this_ ? this_->GetParent() : NULL;
-	if(this_ && parent && event != MOUSEWHEEL)
+	if(this_ && parent && event != MOUSEWHEEL && event != MOUSEHWHEEL)
 		parent->ChildMouseEvent(this, event, p, zdelta, keyflags);
 	return MouseEvent0(event, p, zdelta, keyflags);
 }
@@ -124,6 +124,19 @@ void Ctrl::MouseWheel(Point p, int zd, dword kf)
 		Rect r = parent->GetScreenView();
 		if(r.Contains(p)) {
 			parent->MouseEvent0(MOUSEWHEEL, p - r.TopLeft(), zd, kf);
+			sPropagated = true;
+		}
+	}
+}
+
+void Ctrl::MouseWheelHor(Point p, int zd, dword kf)
+{
+	Ctrl *parent = GetParent();
+	if(parent) {
+		p += GetScreenView().TopLeft();
+		Rect r = parent->GetScreenView();
+		if(r.Contains(p)) {
+			parent->MouseEvent0(MOUSEHWHEEL, p - r.TopLeft(), zd, kf);
 			sPropagated = true;
 		}
 	}
@@ -223,6 +236,9 @@ Image Ctrl::MouseEvent(int event, Point p, int zdelta, dword keyflags)
 		break;
 	case MOUSEWHEEL:
 		MouseWheel(p, zdelta, keyflags);
+		break;
+	case MOUSEHWHEEL:
+		MouseWheelHor(p, zdelta, keyflags);
 		break;
 	case CURSORIMAGE:
 		return CursorImage(p, keyflags);
@@ -531,7 +547,7 @@ bool sDblTime(int time)
 Image Ctrl::DispatchMouse(int e, Point p, int zd) {
 	GuiLock __;
 	EventLevelDo ___;
-	if(e == MOUSEWHEEL && !zd) // ignore non-scroll wheel events
+	if(((e == MOUSEWHEEL)||(e == MOUSEHWHEEL)) && !zd) // ignore non-scroll wheel events
 		return Null;
 	if(e == MOUSEMOVE && repeatTopCtrl == this) {
 		if(sDistMin(leftmousepos, p) > GUI_DragDistance() && GetMouseLeft()) {
@@ -621,7 +637,7 @@ Image Ctrl::DispatchMouseEvent(int e, Point p, int zd) {
 	if(!IsEnabled())
 		return Image::Arrow();
 	Ctrl *top = this;
-	if(e == MOUSEWHEEL && !GetParent()) {
+	if(((e == MOUSEWHEEL)||(e == MOUSEHWHEEL)) && !GetParent()) {
 		Ctrl *w = GetFocusCtrl();
 		if(w) {
 			top = w->GetTopCtrl();

--- a/uppsrc/CtrlCore/GtkEvent.cpp
+++ b/uppsrc/CtrlCore/GtkEvent.cpp
@@ -168,13 +168,22 @@ gboolean Ctrl::GtkEvent(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 		break;
 	case GDK_SCROLL: {
 		GdkEventScroll *e = (GdkEventScroll *)event;
-		if(findarg(e->direction, GDK_SCROLL_UP, GDK_SCROLL_LEFT) >= 0)
-			value = 120;
-		else
-		if(findarg(e->direction, GDK_SCROLL_DOWN, GDK_SCROLL_RIGHT) >= 0)
-			value = -120;
-		else
-			return false;
+		switch(e->direction){
+			case GDK_SCROLL_UP:
+				value = Point(0, 120);
+				break;
+			case GDK_SCROLL_DOWN:
+				value = Point(0, -120);
+				break;
+			case GDK_SCROLL_RIGHT:
+				value = Point(120 ,0);
+				break;
+			case GDK_SCROLL_LEFT:
+				value = Point(-120, 0);
+				break;
+			default:
+				return false;
+		}
 		break;
 	}
 	case GDK_KEY_PRESS:
@@ -571,7 +580,9 @@ void Ctrl::Proc()
 			GtkButtonEvent(UP);
 		break;
 	case GDK_SCROLL: {
-		GtkMouseEvent(MOUSEWHEEL, MOUSEWHEEL, CurrentEvent.value);
+		Point delta = CurrentEvent.value;
+		if(delta.y!=0.0) GtkMouseEvent(MOUSEWHEEL, MOUSEWHEEL, delta.y);
+		if(delta.x!=0.0) GtkMouseEvent(MOUSEHWHEEL, MOUSEHWHEEL, delta.x);
 		break;
 	}
 	case GDK_KEY_PRESS:
@@ -729,7 +740,7 @@ bool Ctrl::ProcessEvent0(bool *quit, bool fetch)
 					b.count += a.count;
 			    else
 			    if(a.type == GDK_SCROLL)
-			        b.value = (int)b.value + (int)a.value;
+			        b.value = (Point)b.value + (Point)a.value;
 				else
 				if(a.type != GDK_CONFIGURE)
 					break;

--- a/uppsrc/CtrlCore/Win32Proc.cpp
+++ b/uppsrc/CtrlCore/Win32Proc.cpp
@@ -340,6 +340,7 @@ LRESULT Ctrl::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		}
 		return 0L;
 	case 0x20a: // WM_MOUSEWHEEL:
+	case 0x20e: // WM_MOUSEHWHEEL:
 		if(ignoreclick) {
 			EndIgnore();
 			return 0L;
@@ -347,7 +348,7 @@ LRESULT Ctrl::WindowProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		if(_this) {
 			Point p(0, 0);
 			::ClientToScreen(hwnd, p);
-			DoMouse(MOUSEWHEEL, Point((dword)lParam) - p, (short)HIWORD(wParam));
+			DoMouse(message == 0x20e ? MOUSEHWHEEL : MOUSEWHEEL, Point((dword)lParam) - p, (short)HIWORD(wParam));
 			CurrentMousePos = Point((dword)lParam);
 		}
 		if(_this) PostInput();


### PR DESCRIPTION
This solution (branch mousewheel3) uses a separate mouse event (MOUSEHWHEEL) for propagating horizontal mouse wheel events. This is quite straight forward and avoids major changes in CtrlCore. Also, this will not cause compatibility issues for existing code. The Ctrls will receive the event as a call to MouseWheelHor(). K_SHIFT is not manipulated.

--

I have also created another branch (mousewheel2) that attempts to pass the mouse wheel in a Point structure. However, this path proved to behave like a snowball rolling down the hill causing a lot of changes all around. In the end, I was not able to make the call to MouseWheel() with Point delta while still supporting current MouseWheel() with int. The reason was that the default Ctrl::MouseWheel() had to exist for propagating unprocessed calls for other Ctrls. So, MouseWheel() with Point delta is not compatible with existing code base. It is worth noting that both Windows and GTK produce the vertical and horizontal wheel events separately, so passing them combined as a point would not yield much benefit. (This would only happen after event compression.)

Finally, the simplest solution of all (now available as branch mousewheel-K_SHIFT), is also available for evaluation on User0755/ultimatepp.

// Tom