### PR TITLE
Add CA certificate authentication to TcpSocket and SSL class

### DIFF
--- a/uppsrc/Core/Inet.h
+++ b/uppsrc/Core/Inet.h
@@ -131,7 +131,7 @@ class TcpSocket : NoCopy {
 	String                  cert, pkey, sni;
 	bool                    asn1;
 	
-	String                  CAcert;
+	String                  ca_cert;
 
 	struct SSLImp;
 	friend struct SSLImp;

--- a/uppsrc/Core/Inet.h
+++ b/uppsrc/Core/Inet.h
@@ -130,6 +130,8 @@ class TcpSocket : NoCopy {
 	One<SSLInfo>            sslinfo;
 	String                  cert, pkey, sni;
 	bool                    asn1;
+	
+	String                  CAcert;
 
 	struct SSLImp;
 	friend struct SSLImp;
@@ -240,6 +242,8 @@ public:
 	void            SSLCertificate(const String& cert, const String& pkey, bool asn1);
 	void            SSLServerNameIndication(const String& name);
 	const SSLInfo  *GetSSLInfo() const                       { return ~sslinfo; }
+	
+	void            SSLCAcert(const String& cert, bool asn1 = false);
 	
 	void            Clear();
 

--- a/uppsrc/Core/SSL/SSL.h
+++ b/uppsrc/Core/SSL/SSL.h
@@ -130,6 +130,8 @@ public:
 	bool     CipherList(const char *list);
 	bool     UseCertificate(String certificate, String private_key, bool cert_asn1 = false);
 	void     VerifyPeer(bool verify = true, int depth = 2);
+	
+	bool     UseCAcert(String CAcert, bool cert_asn1 = false);
 
 private:
 	SSL_CTX *ssl_ctx;

--- a/uppsrc/Core/SSL/SSL.h
+++ b/uppsrc/Core/SSL/SSL.h
@@ -131,7 +131,7 @@ public:
 	bool     UseCertificate(String certificate, String private_key, bool cert_asn1 = false);
 	void     VerifyPeer(bool verify = true, int depth = 2);
 	
-	bool     UseCAcert(String CAcert, bool cert_asn1 = false);
+	bool     UseCAcert(String ca_cert, bool cert_asn1 = false);
 
 private:
 	SSL_CTX *ssl_ctx;

--- a/uppsrc/Core/SSL/Socket.cpp
+++ b/uppsrc/Core/SSL/Socket.cpp
@@ -144,10 +144,10 @@ bool TcpSocket::SSLImp::Start()
 		return false;
 	}
 	
-	if(socket.CAcert.GetCount())
+	if(socket.ca_cert.GetCount())
 	{
 	    context.VerifyPeer(true);
-	    context.UseCAcert(socket.CAcert, socket.asn1);
+	    context.UseCAcert(socket.ca_cert, socket.asn1);
 	}
 	
 	return true;
@@ -194,7 +194,7 @@ dword TcpSocket::SSLImp::Handshake()
 		f.cert_verified = SSL_get_verify_result(ssl) == X509_V_OK;
 	}
 	
-	if(socket.CAcert.GetCount() > 0)
+	if(socket.ca_cert.GetCount() > 0)
 	{
 	    if(f.cert_verified == false)
 	    {

--- a/uppsrc/Core/SSL/Socket.cpp
+++ b/uppsrc/Core/SSL/Socket.cpp
@@ -143,6 +143,13 @@ bool TcpSocket::SSLImp::Start()
 		SetSSLError("Start: SSL_set_fd");
 		return false;
 	}
+	
+	if(socket.CAcert.GetCount())
+	{
+	    context.VerifyPeer(true);
+	    context.UseCAcert(socket.CAcert, socket.asn1);
+	}
+	
 	return true;
 }
 
@@ -186,6 +193,15 @@ dword TcpSocket::SSLImp::Handshake()
 		f.cert_version = cert.GetVersion();
 		f.cert_verified = SSL_get_verify_result(ssl) == X509_V_OK;
 	}
+	
+	if(socket.CAcert.GetCount() > 0)
+	{
+	    if(f.cert_verified == false)
+	    {
+	        SetSSLError("SSL CA invalid");
+	    }
+	}
+	
 	return 0;
 }
 

--- a/uppsrc/Core/SSL/Util.cpp
+++ b/uppsrc/Core/SSL/Util.cpp
@@ -167,6 +167,26 @@ void SslContext::VerifyPeer(bool verify, int depth)
 	SSL_CTX_set_verify_depth(ssl_ctx, depth);
 }
 
+bool SslContext::UseCAcert(String CAcert, bool cert_asn1)
+{
+    ASSERT(ssl_ctx);
+    if(IsNull(CAcert))
+        return false;
+    SslCertificate ca;
+    if(!ca.Load(CAcert, cert_asn1))
+        return false;
+    
+    X509_STORE * castore = SSL_CTX_get_cert_store(ssl_ctx);
+    if(castore == NULL)
+        return false;
+    
+    if(!X509_STORE_add_cert(castore, ca))
+        return false;
+    
+    
+    return true;
+}
+
 String SslGetLastError(int& code)
 {
 	char errbuf[150];

--- a/uppsrc/Core/SSL/Util.cpp
+++ b/uppsrc/Core/SSL/Util.cpp
@@ -183,7 +183,6 @@ bool SslContext::UseCAcert(String CAcert, bool cert_asn1)
     if(!X509_STORE_add_cert(castore, ca))
         return false;
     
-    
     return true;
 }
 

--- a/uppsrc/Core/SSL/Util.cpp
+++ b/uppsrc/Core/SSL/Util.cpp
@@ -167,23 +167,20 @@ void SslContext::VerifyPeer(bool verify, int depth)
 	SSL_CTX_set_verify_depth(ssl_ctx, depth);
 }
 
-bool SslContext::UseCAcert(String CAcert, bool cert_asn1)
+bool SslContext::UseCAcert(String ca_cert, bool cert_asn1)
 {
     ASSERT(ssl_ctx);
-    if(IsNull(CAcert))
+    if(IsNull(ca_cert))
         return false;
     SslCertificate ca;
-    if(!ca.Load(CAcert, cert_asn1))
+    if(!ca.Load(ca_cert, cert_asn1))
         return false;
     
-    X509_STORE * castore = SSL_CTX_get_cert_store(ssl_ctx);
-    if(castore == NULL)
+    auto castore = SSL_CTX_get_cert_store(ssl_ctx);
+    if(!castore)
         return false;
     
-    if(!X509_STORE_add_cert(castore, ca))
-        return false;
-    
-    return true;
+    return X509_STORE_add_cert(castore, ca);
 }
 
 String SslGetLastError(int& code)

--- a/uppsrc/Core/Socket.cpp
+++ b/uppsrc/Core/Socket.cpp
@@ -972,11 +972,9 @@ void TcpSocket::SSLServerNameIndication(const String& name)
 
 void TcpSocket::SSLCAcert(const String& cert, bool asn1_)
 {
-	CAcert = cert;
+	ca_cert = cert;
     asn1 = asn1_;
 }
-
-
 
 void TcpSocket::Clear()
 {

--- a/uppsrc/Core/Socket.cpp
+++ b/uppsrc/Core/Socket.cpp
@@ -970,6 +970,14 @@ void TcpSocket::SSLServerNameIndication(const String& name)
 	sni = name;
 }
 
+void TcpSocket::SSLCAcert(const String& cert, bool asn1_)
+{
+	CAcert = cert;
+    asn1 = asn1_;
+}
+
+
+
 void TcpSocket::Clear()
 {
 	ClearError();


### PR DESCRIPTION
I found the HttpRequest and TcpSocket can not support CA certificate function, this may be have the mitm issue. So I add some code to TcpSocket and SSL class for slove this problem.

After the change, we can use the HttpRequest like this:
```
HttpRequest http;
http.Host(m_ip).Port(m_port).Post(strRequest);
http.SSL(true);
	
String cacrt = "xxxx"; //a string of PEM CA myca.crt
http.SSLCAcert(cacrt);
String strContent =  http.Execute();
```
if the CA cert is not the server.cert's CA ,then report an error "SSL CA invalid".

The CA and Server cert  gen steps:
```
//1. Gen CA file. myca.key, myca.crt
openssl genrsa -aes256 -out myca.key 2048
openssl rsa -in myca.key -out myca.key
openssl req -new -x509 -days 3650 -key myca.key -out myca.crt -subj "/C=CN/ST=SD/L=YT/O=xx/OU=CA/CN=MYCA/emailAddress=youremail@xxx.com"

//2.	gen server.key and server.crt
openssl genrsa -aes256 -out server.key 2048
openssl rsa in server.key -out server.key

openssl req -new -key server.key -out server.csr -subj 
"/C=CN/ST=SD/L=YT/O=xxx/OU=RD/CN=xxx/emailAddress=youremail@xxx.com"

openssl x509 -req -days 3650 -in server.csr -CA myca.crt -CAkey myca.key -CAcreateserial -out server.crt
```


