### PR TITLE
Fix CI/CD by migrating mac to M1 CPU family

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
   build-mac:
     macos:
       xcode: 15.3.0
-    resource_class: macos.m1.medium.gen1
     environment:
       NUMBER_OF_CPUS: 4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build-linux:
     docker:
-      - image: cimg/base:2024.01
+      - image: cimg/base:2024.06
     resource_class: large
     environment:
       NUMBER_OF_CPUS: 4
@@ -16,7 +16,8 @@ jobs:
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
   build-mac:
     macos:
-      xcode: 15.1.0
+      xcode: 15.3.0
+    resource_class: macos.m1.medium.gen1
     environment:
       NUMBER_OF_CPUS: 4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
   build-mac:
     macos:
-      xcode: 15.3.0
+      xcode: 15.4.0
     environment:
       NUMBER_OF_CPUS: 4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: make -f umkMakefile -j ${NUMBER_OF_CPUS}
   build-mac:
     macos:
-      xcode: 15.4.0
+      xcode: 15.3.0
     environment:
       NUMBER_OF_CPUS: 4
     steps:


### PR DESCRIPTION
Intel is no longer supported by CircleCI, so we need to migrate ARM architecture.