### PR TITLE
Update Macro.cpp

### DIFF
--- a/uppsrc/ide/Macro.cpp
+++ b/uppsrc/ide/Macro.cpp
@@ -372,7 +372,7 @@ void Ide::MacroInput(EscEscape& e)
 	else {
 		EscValue out;
 		for(int i = 0; i < tags.GetCount(); i++)
-			out.MapSet(i, (WString)~editors[i]);
+			out.ArrayAdd((WString)~editors[i]);
 		e = out;
 	}
 }


### PR DESCRIPTION
Fixes Input function so it does actually return an array as described in 
https://www.ultimatepp.org/app$ide$macros_en-us.html#2.3

Current behavior only returns the first value of `array = Input(label1, label2)` in array[0]. No other elements are returned.