### PR TITLE
Ide: Fix compilation error and warnings related to MSVC 22

### DIFF
--- a/uppsrc/ide/InstantSetup.cpp
+++ b/uppsrc/ide/InstantSetup.cpp
@@ -330,8 +330,12 @@ void InstantSetup()
 
 				String& myinc = incs.At(ii++);
 				if(IsNull(myinc) || ToLower(myinc).Find("mysql") >= 0)
-					myinc = GetExeDirFile(x64 ? "bin/mysql/include" : "bin/mysql/include");
-
+					myinc = GetExeDirFile("bin/mysql/include");
+				
+				String& llvminc = incs.At(ii++);
+				if(IsNull(llvminc) || ToLower(llvminc).Find("llvm") >= 0)
+					llvminc = GetExeDirFile("bin/llvm");
+				
 				libs.At(0) = vc + (ver17 ? (x64 ? "/lib/x64" : "/lib/x86") : (x64 ? "/lib/amd64" : "/lib"));
 				ii = 1;
 				if(lib.GetCount()) {
@@ -356,6 +360,10 @@ void InstantSetup()
 				String& mylib = libs.At(ii++);
 				if(IsNull(mylib) || ToLower(mylib).Find("mysql") >= 0)
 					mylib = GetExeDirFile(x64 ? "bin/mysql/lib64" : "bin/mysql/lib32");
+				
+				String& llvmlib = libs.At(ii++);
+				if(IsNull(llvmlib) || ToLower(llvmlib).Find("llvm") >= 0)
+					llvmlib = GetExeDirFile("bin/llvm");
 
 				bm.GetAdd("BUILDER") = builder;
 				bmSet(bm, "COMPILER", "");

--- a/uppsrc/ide/LayDes/LayDes.h
+++ b/uppsrc/ide/LayDes/LayDes.h
@@ -342,7 +342,9 @@ private:
 	bool              usegrid;
 	bool              ignoreminsize;
 	bool              sizespring;
-
+	
+	int               layout_zoom = 0;
+	
 	WithMatrixLayout<TopWindow>  matrix;
 	WithSettingLayout<TopWindow> setting;
 
@@ -355,8 +357,6 @@ private:
 		friend unsigned GetHashValue(const TempGroup& g) { return 0; }
 		TempGroup(const String& temp, const String& group) : temp(temp), group(group) {}
 	};
-	
-	int             Zoom = 0;
 	
 	Rect   CtrlRect(Ctrl::LogPos pos, Size sz);
 	Rect   CtrlRectZ(Ctrl::LogPos pos, Size sz);

--- a/uppsrc/ide/LayDes/laydes.cpp
+++ b/uppsrc/ide/LayDes/laydes.cpp
@@ -285,7 +285,7 @@ void LayDes::Paint2(Draw& w)
 void LayDes::MouseWheel(Point p, int zdelta, dword keyflags)
 {
 	if(keyflags & K_CTRL) {
-        Zoom = clamp(Zoom - sgn(zdelta), 0, 15);
+        layout_zoom = clamp(layout_zoom - sgn(zdelta), 0, 15);
 		Refresh();
 		SetBar();
 		SetSb();
@@ -304,7 +304,7 @@ void LayDes::HorzMouseWheel(Point, int zdelta, dword)
 
 double LayDes::GetScale()
 {
-	return (20 - Zoom) / 20.0;
+	return (20 - layout_zoom) / 20.0;
 }
 
 void LayDes::Paint(Draw& w)
@@ -318,7 +318,7 @@ void LayDes::Paint(Draw& w)
 	if(IsNull(currentlayout))
 		return;
 
-	if(Zoom) {
+	if(layout_zoom) {
 		DrawPainter sw(w, sz);
 		sw.Co();
 		sw.Clear(SColorPaper());

--- a/uppsrc/ide/LayDes/laywin.cpp
+++ b/uppsrc/ide/LayDes/laywin.cpp
@@ -178,7 +178,7 @@ void LayDes::OptionBar(Bar& bar)
 {
 	bar.Add("Zoom " + AsString(GetScale() * 100) + "%", MakeZoomIcon(GetScale()),
 		[=] {
-	          Zoom = Zoom < 5 ? 5 : Zoom < 10 ? 10 : 0;
+	          layout_zoom = layout_zoom < 5 ? 5 : layout_zoom < 10 ? 10 : 0;
 		      Refresh();
 		      SetBar();
 		      SetSb();
@@ -265,7 +265,7 @@ void LayDes::Serialize(Stream& s)
 		s % sizespring;
 	s % lsplit % isplit % rsplit;
 	if(version >= 2)
-		s % Zoom;
+		s % layout_zoom;
 	item.SerializeHeader(s);
 	SetBar();
 }

--- a/uppsrc/ide/clang/Visitor.cpp
+++ b/uppsrc/ide/clang/Visitor.cpp
@@ -378,7 +378,7 @@ bool ClangVisitor::ProcessNode(CXCursor cursor)
 		};
 		
 		if(clang_getCursorKind(ref) == CXCursor_OverloadedDeclRef)
-			for(int i = 0; i < clang_getNumOverloadedDecls(ref); i++)
+			for(unsigned int i = 0; i < clang_getNumOverloadedDecls(ref); i++)
 				AddRef(clang_getOverloadedDecl(ref, i));
 		else
 			AddRef(ref);

--- a/uppsrc/ide/ide.cpp
+++ b/uppsrc/ide/ide.cpp
@@ -83,7 +83,7 @@ void Ide::MakeTitle()
 		if(findarg(branch, "", "master", "main") >= 0)
 			editor.BarText(branch, GrayColor(IsDarkTheme() ? 100 : 220));
 		else {
-			dword h = GetHashValue(branch);
+			auto h = GetHashValue(branch);
 			int r = h & 31; h >>= 5;
 			int g = h & 15; h >>= 4;
 			int b = h & 63;


### PR DESCRIPTION
TheIDE doesn't compile with the latest stable MSVC. This PR address this problem. Also, I decieded to change instant setup for MSVC to configure llvm dir by default. With that change MSVC should compile TheIDE out of the box, without the need for manual configuration.