### PR TITLE
Possible Fix to Crash in macOS Silicon in AssistEditor::AssistDisplay…

### DIFF
--- a/uppsrc/ide/AssistDisplay.cpp
+++ b/uppsrc/ide/AssistDisplay.cpp
@@ -149,7 +149,7 @@ String CppText(const String& name, const String& pretty)
 void AssistEditor::AssistDisplay::Paint(Draw& w, const Rect& r, const Value& q, Color ink, Color paper, dword style) const
 {
 	int ii = q;
-	if(ii >= 0 && ii < editor->assist_item_ndx.GetCount()) {
+	if(ii >= 0 && ii < editor->assist_item_ndx.GetCount() && editor->assist_item.GetCount() > 0) {
 		AutoCompleteItem& m = editor->assist_item[editor->assist_item_ndx[ii]];
 
 		w.DrawRect(r, paper);


### PR DESCRIPTION
# Possible Fix to Crash in macOS Silicon in `AssistEditor::AssistDisplay::Paint` 

## File: `./uppsrc/ide/AssistDisplay.cpp`

### Steps to reproduce the error and solve it

1.  Display the **Assist Window** and `Click` on any item
     <img width="1777" alt="1 Click" src="https://github.com/user-attachments/assets/6e6f76f6-a5f5-414c-956a-81c571f51e40" />
     
2. `theide` crash!
     <img width="1458" alt="2 Crash" src="https://github.com/user-attachments/assets/07407ca3-5cfe-4535-aa62-41f2ac3747d9" />

3. The `theide` displays a message the next time it is run
     <img width="812" alt="3 Message" src="https://github.com/user-attachments/assets/48fea5eb-f371-43f1-b6be-b2d7fd40bec8" />

4. The Possible **Fix** to **Crash**
    <img width="1792" alt="4 Fix" src="https://github.com/user-attachments/assets/d354759b-bd20-4b10-ade3-62de42cbe4f6" />

5. Test the display of the assistance window and click on any item
     <img width="1792" alt="5 Test" src="https://github.com/user-attachments/assets/19ae554b-0630-4315-841d-d638f775540a" />



