### PR TITLE
Core/SSH: Package file updated to use crypt32 library on Windows.

### DIFF
--- a/uppsrc/Core/SSH/SSH.upp
+++ b/uppsrc/Core/SSH/SSH.upp
@@ -13,7 +13,7 @@ uses(WIN32 | NOSO) plugin/z;
 
 library(POSIX) "crypto ssl z";
 
-library(WIN32) "ssl crypto";
+library(WIN32) "ssl crypto crypt32";
 
 library(WIN32) "usp10 gdi32 ws2_32";
 


### PR DESCRIPTION
Windows build fails, due to the missing new SSL library requirement: crypt32 library.

This patch aims to solve this issue.