### PR TITLE
Fix GetDefaultUppOut() for Flatpak

### DIFF
--- a/uppsrc/ide/Core/Assembly.cpp
+++ b/uppsrc/ide/Core/Assembly.cpp
@@ -156,6 +156,8 @@ bool SaveVars(const char *name)
 String GetDefaultUppOut()
 {
 	String out;
+	
+#ifndef FLATPAK
 	String p = GetExeFolder();
 	while(p.GetCount() > 1 && DirectoryExists(p)) {
 		String h = AppendFileName(p, ".cache");
@@ -165,6 +167,7 @@ String GetDefaultUppOut()
 		}
 		p = GetFileFolder(p);
 	}
+#endif
 	
 	out = Nvl(out, GetHomeDirFile(".cache")) + "/upp.out";
 	


### PR DESCRIPTION
It looks like version 2024.1 is incompatible with Flatpak. I identified that in GetDefaultUppOut() in ide/Core/Assembly.cpp we are trying to get upp out directory basing on ide executable file. In our Flatpak environment it won't work, because we are using host compiler not the sandboxed one. So, in such case we always need to base on users home directory.