### PR TITLE
Fix a long-standing keyboard shortcuts parsing error.

### DIFF
--- a/uppsrc/CtrlLib/AKeys.cpp
+++ b/uppsrc/CtrlLib/AKeys.cpp
@@ -301,7 +301,7 @@ dword ParseKeyDesc(CParser& p)
 	ONCELOCK  {
 		extern Tuple<dword, const char *> KeyNames__[];
 		for(int i = 0; KeyNames__[i].a; i++) {
-			String n = KeyNames__[i].b;
+			String n = Filter(KeyNames__[i].b, CharFilterNoSpace);
 			int q = n.Find('\v');
 			if(q)
 				n = n.Mid(q + 1);


### PR DESCRIPTION
This one-line patch aims to fix a long-standing bug in the keyboard shortcut parser.

- `Problem`: Currently it is impossible to use `Page Up`, `Page Down` and `Caps Lock` keys (or any combination of these keys with modifier keys) as programmable keyboard shortcuts.

- `Reason`: Keyboard shortcut parser creates a map of existing accelarator keys, using the `KeyNames__` map, defined in `CtrlCore/CtrlKbd.cpp:383`. However, the textual representation of the above mentioned keys contain a space character, which the keyboard shortcut parser in `CtrlLib/AKeys.cpp:238` does not like.

- `Solution`: Filter out the space characters when building the map (which is only used for keyboard shortcuts.)

- See the `reference/AK` example to reproduce the error. It is always reproducible.

This shouldn't break anything. 

Please check.