### PR TITLE
Ide: Minmalize the possibility of scrollbar apperance in version info in about box

### DIFF
--- a/uppsrc/ide/About.cpp
+++ b/uppsrc/ide/About.cpp
@@ -34,13 +34,12 @@ String SplashCtrl::GenerateVersionInfo(bool qtf)
 	h << "Build: " << GenerateVersionNumber();
 #ifdef bmGIT_BRANCH
 	h << " " << bmGIT_BRANCH;
-	h << separator;
 #endif
 
 	if(sizeof(void *) == 8)
-		h << "64 bit";
+		h << " 64 bit";
 	else
-		h << "32 bit";
+		h << " 32 bit";
 #ifdef _MSC_VER
 	h << " MSC";
 #endif
@@ -52,7 +51,9 @@ String SplashCtrl::GenerateVersionInfo(bool qtf)
 #endif
 #endif
 
-#if __cplusplus >= 202000
+#if __cplusplus >= 202300
+	h << " C++23";
+#elif __cplusplus >= 202000
 	h << " C++20";
 #elif __cplusplus >= 201700
 	h << " C++17";
@@ -119,7 +120,7 @@ Size SplashCtrl::MakeLogo(Ctrl& parent, Array<Ctrl>& ctrl)
 		}
 
 	String h;
-	h << "[A+60 \1" << GenerateVersionInfo(true) << "\n";
+	h << "[A+50 \1" << GenerateVersionInfo(true) << "\n";
 	h << "Using: " << MemoryUsedKb()
 #ifdef PLATFORM_COCOA
 		<< " KB of U++ heap\n";
@@ -127,9 +128,9 @@ Size SplashCtrl::MakeLogo(Ctrl& parent, Array<Ctrl>& ctrl)
 		<< " KB\n";
 #endif
 	if(items.GetCount())
-		h << "CodeBase: " << classes.GetCount() << " classes, " << items.GetCount() << " items\n";
+		h << "CodeBase: " << classes.GetCount() << " classes, " << items.GetCount() << " items";
 	if(IsUHDMode())
-		h << "UHD mode\n";
+		h << "UHD mode";
 	v1 = h;
 	v1.HSizePos(DPI(250), DPI(10)).BottomPos(DPI(20), Arial(DPI(20)).GetHeight() * 8);
 	l.Add(v1);


### PR DESCRIPTION
This PR addressing the issue when scrollbar appears in the about box in version information due to too much content. It was achieved by decreasing font from 6 to 5. Also, small issue has been fixed. When there is no information about the branch there is no space between version and bit size of the operating system. Also, to minimize the possibility of scrollbar for version info, the new line at the end has been eliminated.