### PR TITLE
Ide: Add Bobcat to the supported terminals list (linux, bsd, flatpak)

### DIFF
--- a/uppsrc/ide/Core/Host.cpp
+++ b/uppsrc/ide/Core/Host.cpp
@@ -190,6 +190,7 @@ String ResolveHostConsole()
 	
 	#ifdef PLATFORM_BSD
 	static const char *term[] = {
+		"/usr/local/bin/bobcat --",
 		"/usr/local/bin/mate-terminal -x",
 		"/usr/local/bin/gnome-terminal --window -x",
 		"/usr/local/bin/konsole -e",
@@ -200,6 +201,7 @@ String ResolveHostConsole()
 	#else
 		#ifdef FLATPAK
 		static const char *term[] = {
+			"/run/host/bin/bobcat --",
 			"/run/host/bin/mate-terminal -x",
 			"/run/host/bin/gnome-terminal --window -x",
 			"/run/host/bin/konsole -e",
@@ -209,6 +211,7 @@ String ResolveHostConsole()
 		};
 		#else
 		static const char *term[] = {
+			"/usr/bin/bobcat --",
 			"/usr/bin/mate-terminal -x",
 			"/usr/bin/gnome-terminal --window -x",
 			"/usr/bin/konsole -e",
@@ -218,6 +221,7 @@ String ResolveHostConsole()
 		};
 		#endif
 	#endif
+
 	int ii = 0;
 	for(;;) { // If (pre)defined terminal emulator is not available, try to find one
 		int c = HostConsole.Find(' ');

--- a/uppsrc/ide/Debug.cpp
+++ b/uppsrc/ide/Debug.cpp
@@ -199,8 +199,13 @@ void Ide::LaunchTerminal(const char *dir)
 	int q = c.ReverseFind(' ');
 	if(q >= 0)
 		c.Trim(q);
-	if(c.Find("io.elementary.terminal") >= 0) // elementary seems to ignore current dir
+	if(c.Find("io.elementary.terminal") >= 0) { // elementary seems to ignore current dir
 		c <<  " -w \"" << dir << "\"";
+	}
+	else
+	if(int i = c.FindAfter("bobcat"); i >= 0) { // so does Bobcat.
+		c.Insert(i, String() << " -d \"" << dir << "\" ");
+	}
 	h.Launch(Nvl(c, "/usr/bin/xterm"), false);
 #endif
 }


### PR DESCRIPTION
- This PR adds [Bobcat](https://github.com/ismail-yilmaz/Bobcat) to the supported terminals list.
- Currently it is only applied to linux, bsd and flatpak environments but if accepted, a patch for windows will also follow.
- Currently if no other terminal but Bobcat is detected, TheIDE will try to use it. 

Please check.


