### PR TITLE
Umk: Git exe file path fix for windows builds.

### DIFF
--- a/uppsrc/ide/Builders/CppBuilder.cpp
+++ b/uppsrc/ide/Builders/CppBuilder.cpp
@@ -554,13 +554,14 @@ Vector<String> RepoInfo(const String& package)
 	if(repo == GIT_DIR) {
 		String h = GetCurrentDirectory();
 		SetCurrentDirectory(d);
-		String v = HostSys("git rev-list --count HEAD");
+		String gitpath = GetGitPath();
+		String v = HostSys(gitpath + " rev-list --count HEAD");
 		if(IsDigit(*v))
 			info.Add("#define bmGIT_REVCOUNT " + AsCString(TrimBoth(v)));
-		v = HostSys("git rev-parse HEAD");
+		v = HostSys(gitpath + " rev-parse HEAD");
 		if(v.GetCount())
 			info.Add("#define bmGIT_HASH " + AsCString(TrimBoth(v)));
-		v = HostSys("git rev-parse --abbrev-ref HEAD");
+		v = HostSys(gitpath + " rev-parse --abbrev-ref HEAD");
 		if(v.GetCount())
 			info.Add("#define bmGIT_BRANCH " + AsCString(TrimBoth(v)));
 		SetCurrentDirectory(h);

--- a/uppsrc/ide/Core/Core.h
+++ b/uppsrc/ide/Core/Core.h
@@ -648,5 +648,6 @@ enum { NOT_REPO_DIR = 0, SVN_DIR, GIT_DIR };
 
 int    GetRepoKind(const String& p);
 int    GetRepo(String& path);
+String GetGitPath();
 
 #endif

--- a/uppsrc/ide/Core/Util.cpp
+++ b/uppsrc/ide/Core/Util.cpp
@@ -25,3 +25,17 @@ int GetRepoKind(const String& p)
 	String pp = p;
 	return GetRepo(pp);
 }
+
+String GetGitPath()
+{
+#ifdef PLATFORM_WIN32
+	static String path;
+	ONCELOCK {
+		path = AppendFileName(GetExeFolder(), "\\bin\\mingit\\cmd\\git.exe");
+		path = FileExists(path) ? "\"" + path + "\"" : "git";
+	}
+	return path;
+#else
+	return "git";
+#endif
+}

--- a/uppsrc/umk/UppHub.cpp
+++ b/uppsrc/umk/UppHub.cpp
@@ -131,7 +131,7 @@ void UppHubDlg::Install(const Index<String>& ii_, bool update)
 			if(n) {
 				String dir = GetHubDir() + '/' + n->name;
 				if(!DirectoryExists(dir)) {
-					String cmd = "git clone ";
+					String cmd = GetGitPath() + " clone ";
 					if(n->branch.GetCount())
 						cmd << "-b " + n->branch << ' ';
 					cmd << n->repo;
@@ -150,11 +150,11 @@ void UppHubDlg::Install(const Index<String>& ii_, bool update)
 									}
 					}
 				} else if (update) {
-					String cmd = "git -C ";
+					String cmd = GetGitPath() + " -C ";
 					cmd << dir << " clean -fxd";
 					PutConsole(cmd);
 					system(cmd);
-					cmd = "git -C ";
+					cmd = GetGitPath() + " -C ";
 					cmd << dir << " pull";
 					PutConsole(cmd);
 					system(cmd);


### PR DESCRIPTION
This PR addresses the Git executable path issue on Windows. (See: issue #220)  

### **Problem**  
Currently, **umk** uses only `"git"` as the executable path on both POSIX systems and Windows. While this works fine on POSIX, it causes issues on Windows because the system searches for Git in system directories. If Git is not installed globally, **umk** fails to perform Git-related operations (e.g., UppHub).  

### **Solution**  
Since **mingit** is shipped by default, **umk** should first attempt to locate its executable, assuming it resides in a path relative to **umk**'s executable folder.  

This PR introduces a function: **`GetGitPath()`**, which:  
1. First checks for **mingit’s** executable.  
2. If not found, falls back to the default `"git"` executable.  

This ensures **umk** can reliably use Git on Windows.  


