### PR TITLE
New simd functions (GetMask variants (i8, i16, i32, f32) and equality operator (i8) for SSE2 and NEON).

### DIFF
--- a/autotest/SIMD3/Etalon.log
+++ b/autotest/SIMD3/Etalon.log
@@ -1,0 +1,11 @@
+* /home/maldoror/upp/.cache/upp.out/autotest/CLANG.Debug.Debug_Full.Shared.Sse2/SIMD3 08.02.2025 12:19:08, user: maldoror
+
+mask1 = 0xaaaa
+mask2 = 0xaa
+mask3 = 0xa
+mask4 = 0xa
+=================
+All zeros:   0x0000 (expected: 0x0000)
+All ones:    0xffff (expected: 0xffff)
+Alternating: 0xaaaa (expected: 0xaaaa)
+Single bit:  0x0020 (expected: 0x0020)

--- a/autotest/SIMD3/SIMD3.cpp
+++ b/autotest/SIMD3/SIMD3.cpp
@@ -30,7 +30,7 @@ CONSOLE_APP_MAIN
 	DUMPHEX(mask4);
 	ASSERT(mask4 == 0b1010);
 	
-	LOG("==================================");
+	LOG("=================");
 	
 	// Test 2
 	byte p[16] = {0};
@@ -57,6 +57,8 @@ CONSOLE_APP_MAIN
 	s[5] = 0x80;  // Set MSB of 6th byte
 	mask4 = GetMaski8x16(s);
 	LOG(Format("Single bit:  0x%04x (expected: 0x0020)", mask4));
+
+	CheckLogEtalon();
 	
 #else
 	Cout() << "================= NO SIMD\r\n";

--- a/autotest/SIMD3/SIMD3.cpp
+++ b/autotest/SIMD3/SIMD3.cpp
@@ -1,0 +1,64 @@
+#include <Core/Core.h>
+
+using namespace Upp;
+
+CONSOLE_APP_MAIN
+{
+	StdLogSetup(LOG_FILE|LOG_COUT);
+
+#ifdef CPU_SIMD
+
+	i8x16 a(-1, 2, -3, 4, -5, 6, -7, 8, -9, 10, -11, 12, -13, 14, -15, 16);
+	i16x8 b(-1, 2, -3, 4, -5, 6, -7, 8 );
+	i32x4 c(-1, 2, -3, 4);
+	f32x4 d(-1.0f, 2.0f, -3.0f, 4.0f);
+
+	// Test 1
+	auto mask1 = GetMaski8x16(a);
+	DUMPHEX(mask1);
+	ASSERT(mask1 == 0b1010101010101010);
+
+	auto mask2 = GetMaski16x8(b);
+	DUMPHEX(mask2);
+	ASSERT(mask2 == 0b10101010);
+
+	auto mask3 = GetMaski32x4(c);
+	DUMPHEX(mask3);
+	ASSERT(mask3 == 0b1010);
+	
+	auto mask4 = GetMaskf32x4(d);
+	DUMPHEX(mask4);
+	ASSERT(mask4 == 0b1010);
+	
+	LOG("==================================");
+	
+	// Test 2
+	byte p[16] = {0};
+	mask1 = GetMaski8x16(p);
+	// Case 1: All zeros
+	LOG(Format("All zeros:   0x%04x (expected: 0x0000)", mask1));
+
+	// Case 2: All ones
+	byte q[16];
+	for (int i = 0; i < 16; i++)
+		q[i] = 0xFF;
+	mask2 = GetMaski8x16(q);
+	LOG(Format("All ones:    0x%04x (expected: 0xffff)", mask2));
+
+	// Test case 3: Alternating pattern
+	byte r[16];
+	for (int i = 0; i < 16; i++)
+		r[i] = (i % 2) ? 0x80 : 0x00;
+	mask3 = GetMaski8x16(r);
+	LOG(Format("Alternating: 0x%04x (expected: 0xaaaa)", mask3));
+
+	// Test case 4: Single bit set
+	byte s[16] = {0};
+	s[5] = 0x80;  // Set MSB of 6th byte
+	mask4 = GetMaski8x16(s);
+	LOG(Format("Single bit:  0x%04x (expected: 0x0020)", mask4));
+	
+#else
+	Cout() << "================= NO SIMD\r\n";
+#endif	
+}

--- a/autotest/SIMD3/SIMD3.upp
+++ b/autotest/SIMD3/SIMD3.upp
@@ -1,0 +1,9 @@
+uses
+	Core;
+
+file
+	SIMD3.cpp;
+
+mainconfig
+	"" = "SSE2";
+

--- a/autotest/SIMD3/SIMD3.upp
+++ b/autotest/SIMD3/SIMD3.upp
@@ -2,6 +2,7 @@ uses
 	Core;
 
 file
+	Etalon.log,
 	SIMD3.cpp;
 
 mainconfig

--- a/uppsrc/Core/SIMD_NEON.h
+++ b/uppsrc/Core/SIMD_NEON.h
@@ -28,6 +28,15 @@ struct f32x4 {
 	operator float32x4_t()       { return data; }
 };
 
+force_inline int GetMaskf32x4(f32x4 a)
+{
+    uint32x4_t shifted = vshrq_n_u32(vreinterpretq_u32_f32(a.data), 31);
+    return (vgetq_lane_u32(shifted, 0) << 0) |
+           (vgetq_lane_u32(shifted, 1) << 1) |
+           (vgetq_lane_u32(shifted, 2) << 2) |
+           (vgetq_lane_u32(shifted, 3) << 3);
+}
+
 force_inline f32x4  f32all(double f) { return vdupq_n_f32((float)f); }
 
 force_inline f32x4  operator+(f32x4 a, f32x4 b)   { return vaddq_f32(a, b); }
@@ -95,6 +104,18 @@ struct i16x8 { // 8xint16
 	operator int16x8_t()         { return data; }
 };
 
+force_inline int GetMaski16x8(i16x8 a)
+{
+    uint16x8_t shifted = vshrq_n_u16(vreinterpretq_u16_s16(a.data), 15);
+    return (vgetq_lane_u16(shifted, 0) << 0) |
+           (vgetq_lane_u16(shifted, 1) << 1) |
+           (vgetq_lane_u16(shifted, 2) << 2) |
+           (vgetq_lane_u16(shifted, 3) << 3) |
+           (vgetq_lane_u16(shifted, 4) << 4) |
+           (vgetq_lane_u16(shifted, 5) << 5) |
+           (vgetq_lane_u16(shifted, 6) << 6) |
+           (vgetq_lane_u16(shifted, 7) << 7);
+}
 
 force_inline i16x8  i16all(int v)                  { return vdupq_n_s16(v); }
 
@@ -151,6 +172,15 @@ struct i32x4 { // 4xint32
 	operator int()               { return vgetq_lane_s32(data, 0); }
 	operator i16x8() const       { return i16x8(data); }
 };
+
+force_inline int GetMaski32x4(i32x4 a)
+{
+    uint32x4_t shifted = vshrq_n_u32(vreinterpretq_u32_s32(a.data), 31);
+    return (vgetq_lane_u32(shifted, 0) << 0) |
+           (vgetq_lane_u32(shifted, 1) << 1) |
+           (vgetq_lane_u32(shifted, 2) << 2) |
+           (vgetq_lane_u32(shifted, 3) << 3);
+}
 
 force_inline i32x4  i32all(int v)                 { return vdupq_n_s32(v); }
 
@@ -210,6 +240,27 @@ struct i8x16 { // 16*int8
 	operator int8x16_t() const   { return data; }
 	operator i16x8() const       { return i16x8(data); }
 };
+
+force_inline int GetMaski8x16(i8x16 a)
+{
+    uint8x16_t shifted = vshrq_n_u8(vreinterpretq_u8_s8(a.data), 7);
+    return (vgetq_lane_u8(shifted, 0) << 0)   |
+           (vgetq_lane_u8(shifted, 1) << 1)   |
+           (vgetq_lane_u8(shifted, 2) << 2)   |
+           (vgetq_lane_u8(shifted, 3) << 3)   |
+           (vgetq_lane_u8(shifted, 4) << 4)   |
+           (vgetq_lane_u8(shifted, 5) << 5)   |
+           (vgetq_lane_u8(shifted, 6) << 6)   |
+           (vgetq_lane_u8(shifted, 7) << 7)   |
+           (vgetq_lane_u8(shifted, 8) << 8)   |
+           (vgetq_lane_u8(shifted, 9) << 9)   |
+           (vgetq_lane_u8(shifted, 10) << 10) |
+           (vgetq_lane_u8(shifted, 11) << 11) |
+           (vgetq_lane_u8(shifted, 12) << 12) |
+           (vgetq_lane_u8(shifted, 13) << 13) |
+           (vgetq_lane_u8(shifted, 14) << 14) |
+           (vgetq_lane_u8(shifted, 15) << 15);
+}
 
 force_inline i8x16  i8all(int v)                  { return vdupq_n_s8(v); }
 

--- a/uppsrc/Core/SIMD_NEON.h
+++ b/uppsrc/Core/SIMD_NEON.h
@@ -264,6 +264,8 @@ force_inline int GetMaski8x16(i8x16 a)
 
 force_inline i8x16  i8all(int v)                  { return vdupq_n_s8(v); }
 
+force_inline i8x16  operator==(i8x16 a, i8x16 b)  { return vreinterpretq_s8_u8(vceqq_s8(a.data, b.data)); }
+
 force_inline i8x16  operator+(i8x16 a, i8x16 b)   { return vaddq_s8(a, b); }
 force_inline i8x16& operator+=(i8x16& a, i8x16 b) { return a = a + b; }
 force_inline i8x16  operator-(i8x16 a, i8x16 b)   { return vsubq_s8(a, b); }

--- a/uppsrc/Core/SIMD_SSE2.h
+++ b/uppsrc/Core/SIMD_SSE2.h
@@ -20,6 +20,8 @@ struct f32x4 {
 	operator __m128()            { return data; }
 };
 
+force_inline int GetMaskf32x4(f32x4 a)            { return _mm_movemask_ps(a.data); }
+
 force_inline f32x4  f32all(double f)              { return _mm_set1_ps((float)f); }
 
 force_inline f32x4  operator+(f32x4 a, f32x4 b)   { return _mm_add_ps(a.data, b.data); }
@@ -69,6 +71,12 @@ struct i16x8 { // 8xint16
 	operator __m128i()           { return data; }
 };
 
+force_inline int GetMaski16x8(i16x8 a)
+{
+    return (_mm_movemask_ps(_mm_castsi128_ps(_mm_srai_epi32(_mm_unpacklo_epi16(a.data, a.data), 16)))
+        |  (_mm_movemask_ps(_mm_castsi128_ps(_mm_srai_epi32(_mm_unpackhi_epi16(a.data, a.data), 16))) << 4));
+}
+
 force_inline i16x8  i16all(int v)                  { return _mm_set1_epi16(v); }
 
 force_inline i16x8  operator+(i16x8 a, i16x8 b)    { return _mm_add_epi16(a.data, b.data); }
@@ -105,6 +113,8 @@ struct i32x4 : i16x8 { // 4xint32
 	operator int()               { return _mm_cvtsi128_si32(data); }
 };
 
+force_inline int GetMaski32x4(i16x8 a)            { return _mm_movemask_ps(_mm_castsi128_ps(a.data)); }
+
 force_inline i32x4  i32all(int v)                 { return _mm_set1_epi32(v); }
 
 force_inline i32x4  operator+(i32x4 a, i32x4 b)   { return _mm_add_epi32(a.data, b.data); }
@@ -139,6 +149,8 @@ struct i8x16 : i16x8 { // 16xint8
 	                             { data = _mm_set_epi8(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p); }
 };
 
+inline int GetMaski8x16(i8x16 a)                  { return _mm_movemask_epi8(a.data); }
+
 force_inline i8x16  i8all(int v)                  { return _mm_set1_epi8(v); }
 
 force_inline i8x16  operator+(i8x16 a, i8x16 b)   { return _mm_add_epi8(a.data, b.data); }
@@ -156,6 +168,7 @@ force_inline i8x16  operator~(i8x16 a)            { return _mm_xor_si128(a.data,
 
 force_inline f32x4 ToFloat(i32x4 a)               { return _mm_cvtepi32_ps(a.data); }
 force_inline i32x4 Truncate(f32x4 a)              { return _mm_cvttps_epi32(a.data); }
+
 // force_inline i32x4 Round(f32x4 a)                 { return _mm_cvtps_epi32(a.data); }
 
 force_inline i16x8 Unpack8L(i16x8 a)              { return _mm_unpacklo_epi8(a.data, _mm_setzero_si128()); }

--- a/uppsrc/Core/SIMD_SSE2.h
+++ b/uppsrc/Core/SIMD_SSE2.h
@@ -153,6 +153,8 @@ inline int GetMaski8x16(i8x16 a)                  { return _mm_movemask_epi8(a.d
 
 force_inline i8x16  i8all(int v)                  { return _mm_set1_epi8(v); }
 
+force_inline i8x16  operator==(i8x16 a, i8x16 b)  { return _mm_cmpeq_epi8(a.data, b.data); }
+
 force_inline i8x16  operator+(i8x16 a, i8x16 b)   { return _mm_add_epi8(a.data, b.data); }
 force_inline i8x16& operator+=(i8x16& a, i8x16 b) { return a = a + b; }
 force_inline i8x16  operator-(i8x16 a, i8x16 b)   { return _mm_sub_epi8(a.data, b.data); }


### PR DESCRIPTION
This PR adds some very useful and crucial code seemingly missing in U++ SIMD functions: `GetMaski8x16()`, `GetMaski16x8()`,  `GetMaski32x4()`, `GetMaskf32x4()`.

These functions allow developers to do some very useful operations easily using the SIMD instructions: Counting, accumulating and determining positions in arrays (e.g they can be used to vectorize string/byte searches).

A simple example is `reference/StreamGetSzPointer` example. The vectorized version of the example can be as follows:

```
int CountLinesOptimizedSIMD(Stream& s) {
	int n = 0;

	for (;;) {
		int sz;
		const byte* p = s.GetSzPtr(sz);

		if (sz) {
			const byte* e = p + sz;
			const byte* e16 = p + (sz & ~15);  // Process in 16-byte chunks
			i8x16 q = i8all('\n');
			while(p < e16) {
				int mask = GetMaski8x16((i8x16(p) == q));
				n += __builtin_popcount(mask); // Unfortunately, this seems to be CLANG/GCC specific.
				p += 16;
			}

			// Process remaining bytes (less than 16)
			while (p < e) {
				n += (*p++ == '\n');
			}
		}
		else {
			int c = s.Get();
			if (c < 0)
				return n;
			n += (c == '\n');
		}
	}

	return n;
}



```
The results of this operation with a ~2Gib file on a Ryzen 5600 with 16 Gib RAM (CLANG) is as follows (note that the scalar version is increased to 16 bytes chunks and 16 newline checks to give the compiler an opportunity to vectorize): 

```
CountLines(in) = 59150432
Simple 1.500799 s
CountLinesOptimized(in) = 59150432
Optimized 717.475 ms
CountLinesOptimizedSIMD(in) = 59150432
Optimized with SIMD 616.997 ms

```
Admittedly, this is not definitive, GCC can better vectorize and in fact it does. However, the aim of this example is to show how the usage pattern can be simplified using masks and equality operator for i8x16 data type.

There is also an autotest for the patch.

Please check.

