### PR TITLE
CtrlCore: Fix default window size when CSD is enable

### DIFF
--- a/uppsrc/CtrlCore/GtkCreate.cpp
+++ b/uppsrc/CtrlCore/GtkCreate.cpp
@@ -83,7 +83,8 @@ void Ctrl::Create(Ctrl *owner, bool popup)
 
 	gtk_window_set_default_size(gtk(), LSC(r.GetWidth()), LSC(r.GetHeight()));
 	gtk_window_move(gtk(), LSC(r.left), LSC(r.top));
-	gtk_window_resize(gtk(), LSC(r.GetWidth()), LSC(r.GetHeight()));
+	gtk_window_resize(gtk(), LSC(r.GetWidth()) - top->csd.ExtraWidth(),
+	                  LSC(r.GetHeight()) - top->csd.ExtraHeight());
 		
 	if (top->header) {
 		gtk_container_add(GTK_CONTAINER(top->window), top->drawing_area);


### PR DESCRIPTION
It looks like the initial window size is too big for window with CSD enable. In order to avoid that we need to remove extra width and height added by CSD.

top->csd.ExtraWidth() is not within LSC, because this value was normalized in GtkCSD::Create.