### PR TITLE
CtrlCore: Fix issue with nested menubars on Wayland

### DIFF
--- a/uppsrc/CtrlCore/GtkCapture.cpp
+++ b/uppsrc/CtrlCore/GtkCapture.cpp
@@ -64,8 +64,11 @@ void Ctrl::StartGrabPopup()
 		Ctrl *w = activePopup[0];
 		if(w && w->IsOpen()) {
 			ReleaseWndCapture0();
-			if(w->GrabMouse())
+			// NOTE: On Wayland GrabMouse() is broken and shouldn't be used. Also gdk_device_grab()
+			// and gdk_seat_grab() are removed in GTK4.
+			if(IsWayland() || w->GrabMouse()) {
 				grabpopup = w;
+			}
 		}
 	}
 }

--- a/uppsrc/CtrlCore/GtkCapture.cpp
+++ b/uppsrc/CtrlCore/GtkCapture.cpp
@@ -64,8 +64,7 @@ void Ctrl::StartGrabPopup()
 		Ctrl *w = activePopup[0];
 		if(w && w->IsOpen()) {
 			ReleaseWndCapture0();
-			// NOTE: On Wayland GrabMouse() is broken and shouldn't be used. Also gdk_device_grab()
-			// and gdk_seat_grab() are removed in GTK4.
+			// NOTE: On Wayland GrabMouse() is broken and shouldn't be used.
 			if(IsWayland() || w->GrabMouse()) {
 				grabpopup = w;
 			}


### PR DESCRIPTION
This change fix the issue with lack of focus for nested menubars on Wayland. The issue was caused by unnecessary call to GrabMouse() function on Wayland. Moreover in GTK4 gdk_seat_grab and gdk_device_grab were removed (https://docs.gtk.org/gtk4/migrating-3to4.html#stop-using-grabs). So, sooner or later we should stop using them.

This is safe fix and I recommend it for 2025.1. It only affects Wayland, For X11 everything is the same.