### PR TITLE
Tutorial(Gui24): make text readable under dark theme

### DIFF
--- a/tutorial/Gui24/main.cpp
+++ b/tutorial/Gui24/main.cpp
@@ -13,7 +13,7 @@ struct MyAppWindow : TopWindow {
     
     void Paint(Draw& w) override {
         w.DrawRect(GetSize(), SLtYellow);
-        w.DrawText(20, 20, t_("Hello translation engine!"), Arial(30), Blue);
+        w.DrawText(20, 20, t_("Hello translation engine!"), Arial(30), SBlue);
     }
 };
 


### PR DESCRIPTION
Make text readable under dark theme by changing the text color to `SBlue`.

Before the patch:

![image](https://github.com/user-attachments/assets/cb9a9854-a96d-470e-9472-942beb558436)

After the patch:

![image](https://github.com/user-attachments/assets/817687ac-61a2-488a-afc1-0888745d4c21)

Also, `zh-cn` is Simplified Chinese instead of Traditional Chinese (which is `zh-tw` or `zh-hk`). I can submit another PR to correct the language issue.

By the way: Does TheIDE itself support localization? How can I change the UI language of TheIDE to, for example, Chinese? I can't find related option across the IDE settings dialog, did I miss something?