### PR TITLE
Core: ProcessHasAdminRights() function is added to utility functions.

### DIFF
--- a/reference/DetectPrivilegedProcess/DetectPrivilegedProcess.upp
+++ b/reference/DetectPrivilegedProcess/DetectPrivilegedProcess.upp
@@ -1,0 +1,11 @@
+description "Detects and warns if the app is running in root/admin mode.\377";
+
+uses
+	CtrlLib;
+
+file
+	main.cpp;
+
+mainconfig
+	"" = "GUI";
+

--- a/reference/DetectPrivilegedProcess/main.cpp
+++ b/reference/DetectPrivilegedProcess/main.cpp
@@ -5,7 +5,7 @@ using namespace Upp;
 GUI_APP_MAIN
 {
 	// Run the example as administrator (Windows) or as root (POSIX) to get the warning.
-	if(IsAdmin())
+	if(IsUserAdmin())
 		Exclamation(t_("Warning: Application has administrator/root rights.&This might pose a security risk!"));
 	else
 		PromptOK(t_("Application has user rights."));

--- a/reference/DetectPrivilegedProcess/main.cpp
+++ b/reference/DetectPrivilegedProcess/main.cpp
@@ -5,7 +5,7 @@ using namespace Upp;
 GUI_APP_MAIN
 {
 	// Run the example as administrator (Windows) or as root (POSIX) to get the warning.
-	if(ProcessHasAdminRights())
+	if(IsAdmin())
 		Exclamation(t_("Warning: Application has administrator/root rights.&This might pose a security risk!"));
 	else
 		PromptOK(t_("Application has user rights."));

--- a/reference/DetectPrivilegedProcess/main.cpp
+++ b/reference/DetectPrivilegedProcess/main.cpp
@@ -1,0 +1,12 @@
+#include <CtrlLib/CtrlLib.h>
+
+using namespace Upp;
+
+GUI_APP_MAIN
+{
+	// Run the example as administrator (Windows) or as root (windows) to get the warning.
+	if(ProcessHasAdminRights())
+		Exclamation(t_("Warning: Application has administrator/root rights.&This might pose a security risk!"));
+	else
+		PromptOK(t_("Application has user rights."));
+}

--- a/reference/DetectPrivilegedProcess/main.cpp
+++ b/reference/DetectPrivilegedProcess/main.cpp
@@ -4,7 +4,7 @@ using namespace Upp;
 
 GUI_APP_MAIN
 {
-	// Run the example as administrator (Windows) or as root (windows) to get the warning.
+	// Run the example as administrator (Windows) or as root (POSIX) to get the warning.
 	if(ProcessHasAdminRights())
 		Exclamation(t_("Warning: Application has administrator/root rights.&This might pose a security risk!"));
 	else

--- a/uppsrc/Core/App.cpp
+++ b/uppsrc/Core/App.cpp
@@ -864,5 +864,29 @@ String GetProgramDataFolder() { return String("/var/opt"); }
 
 #endif
 
+bool ProcessHasAdminRights()
+{
+#ifdef PLATFORM_POSIX
+    return geteuid() == 0;
+#elif PLATFORM_WIN32
+    BOOL isAdmin = FALSE;
+    PSID pAdminGroup = nullptr;
+    SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
+    if(AllocateAndInitializeSid(
+				&NtAuthority,
+				2,
+				SECURITY_BUILTIN_DOMAIN_RID,
+				DOMAIN_ALIAS_RID_ADMINS,
+				0, 0, 0, 0, 0, 0,
+				&pAdminGroup)) {
+        CheckTokenMembership(nullptr, pAdminGroup, &isAdmin);
+        FreeSid(pAdminGroup);
+    }
+    return isAdmin;
+#else
+    // Unsupported platform. (Assume no elevation).
+    return false;
+#endif
+}
 
 }

--- a/uppsrc/Core/App.cpp
+++ b/uppsrc/Core/App.cpp
@@ -864,7 +864,7 @@ String GetProgramDataFolder() { return String("/var/opt"); }
 
 #endif
 
-bool IsAdmin()
+bool IsUserAdmin()
 {
 #ifdef PLATFORM_POSIX
     return geteuid() == 0;
@@ -884,7 +884,7 @@ bool IsAdmin()
     }
     return isAdmin;
 #else
-    // Unsupported platform. (Assume no elevation).
+    // Unsupported platform. (Assume no elevation.)
     return false;
 #endif
 }

--- a/uppsrc/Core/App.cpp
+++ b/uppsrc/Core/App.cpp
@@ -864,7 +864,7 @@ String GetProgramDataFolder() { return String("/var/opt"); }
 
 #endif
 
-bool ProcessHasAdminRights()
+bool IsAdmin()
 {
 #ifdef PLATFORM_POSIX
     return geteuid() == 0;

--- a/uppsrc/Core/App.h
+++ b/uppsrc/Core/App.h
@@ -116,4 +116,6 @@ String GetTemplatesFolder();
 String GetDownloadFolder();
 String GetProgramDataFolder();
 
+bool   ProcessHasAdminRights();
+
 void   InstallCrashHook(void (*h)());

--- a/uppsrc/Core/App.h
+++ b/uppsrc/Core/App.h
@@ -116,6 +116,6 @@ String GetTemplatesFolder();
 String GetDownloadFolder();
 String GetProgramDataFolder();
 
-bool   IsAdmin();
+bool   IsUserAdmin();
 
 void   InstallCrashHook(void (*h)());

--- a/uppsrc/Core/App.h
+++ b/uppsrc/Core/App.h
@@ -116,6 +116,6 @@ String GetTemplatesFolder();
 String GetDownloadFolder();
 String GetProgramDataFolder();
 
-bool   ProcessHasAdminRights();
+bool   IsAdmin();
 
 void   InstallCrashHook(void (*h)());

--- a/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
+++ b/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
@@ -224,6 +224,11 @@ tring]_[* GetDesktopManager]()&]
 the value of `"DESKTOP`_SESSION`" environment variable is returned.&]
 [s3; &]
 [s4; &]
+[s5;:Upp`:`:ProcessHasAdminRights`(`): [@(0.0.255) bool] [* ProcessHasAdminRights]()&]
+[s2;%% Return true if the current process is running as administrator 
+(Windows) or root (POSIX).&]
+[s3; &]
+[s4; &]
 [s5;:LaunchWebBrowser`(const String`&`): [@(0.0.255) void]_[* LaunchWebBrowser]([@(0.0.255) c
 onst]_[_^topic`:`/`/Core`/src`/String`$en`-us`#String`:`:class^ String][@(0.0.255) `&
 ]_[*@3 url])&]

--- a/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
+++ b/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
@@ -224,7 +224,7 @@ tring]_[* GetDesktopManager]()&]
 the value of `"DESKTOP`_SESSION`" environment variable is returned.&]
 [s3; &]
 [s4; &]
-[s5;:Upp`:`:IsAdmin`(`): [@(0.0.255) bool] [* IsAdmin]()&]
+[s5;:Upp`:`:IsUserAdmin`(`): [@(0.0.255) bool] [* IsUserAdmin]()&]
 [s2;%% Return true if the current process is running as administrator 
 (Windows) or root (POSIX).&]
 [s3; &]

--- a/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
+++ b/uppsrc/Core/src.tpp/AppEnv_en-us.tpp
@@ -224,7 +224,7 @@ tring]_[* GetDesktopManager]()&]
 the value of `"DESKTOP`_SESSION`" environment variable is returned.&]
 [s3; &]
 [s4; &]
-[s5;:Upp`:`:ProcessHasAdminRights`(`): [@(0.0.255) bool] [* ProcessHasAdminRights]()&]
+[s5;:Upp`:`:IsAdmin`(`): [@(0.0.255) bool] [* IsAdmin]()&]
 [s2;%% Return true if the current process is running as administrator 
 (Windows) or root (POSIX).&]
 [s3; &]


### PR DESCRIPTION
Sometimes it is very useful to know if the current process/app is running in administrator/root mode. In this way, developers can enable or disable certain set of features or warn the user about the security risk posed by escalated privileges.

This PR,

- Adds `ProcessHasAdminRights()` function to U++, which can check if the current process is running in admin (Win) or root (POSIX) mode.  
- Adds the relevant example.
- Adds the relevant API doc entry.

Tested on Linux, Win 10/11.

Please review.