### PR TITLE
RichEdit: Fix issue with unresponsive menu bar after right click on Wayland

### DIFF
--- a/uppsrc/RichEdit/Mouse.cpp
+++ b/uppsrc/RichEdit/Mouse.cpp
@@ -325,7 +325,6 @@ void RichEdit::RightDown(Point p, dword flags)
 	bar_object.Clear();
 	bar_fieldparam = Null;
 	if(!GetSelection(l, h)) {
-		LeftDown(p, flags);
 		if(objectpos >= 0)
 			o = bar_object = GetObject();
 		else {


### PR DESCRIPTION
It seems that executing LeftDown when text is not slected in RightDawn in RichEdit doesn't make much sense. After removing this line the Wayland version of RichEdit works as expected and right click menu bar when there is no selection behaves as expected.

Not sure if there is a drawback of removing of LeftDawn, hoever I didn't notice anything bad.