### PR TITLE
Ide: Fix issue with leading saprator in AssistInsert menu

### DIFF
--- a/uppsrc/ide/Insert.cpp
+++ b/uppsrc/ide/Insert.cpp
@@ -270,8 +270,9 @@ void Ide::InsertMenu(Bar& bar)
 				n++;
 			}
 		}
+		if(n > 0)
+			bar.Separator();
 	}
-	bar.Separator();
 	bar.Add("Insert color..", THISBACK(InsertColor));
 	bar.Add("Insert .iml Image..", [=] { InsertImage(); });
 	bar.Add("Insert sequence..", THISBACK(InsertSequence));


### PR DESCRIPTION
When there are no special files in AssistInerst menu the menu starts with separator. This PR is fixing this problem. Fix relativly safty and can be part of 2025.1.