### PR TITLE
MacOS: Enable cross-compilation.

### DIFF
--- a/uppsrc/ide/Builders/Builders.h
+++ b/uppsrc/ide/Builders/Builders.h
@@ -87,6 +87,9 @@ struct GccBuilder : CppBuilder {
 	                 const String& link_options);
 
 	String Info_plist; // apple bundle Info.plist
+
+  protected:
+    String MakeToolName(const char* tn);
 };
 
 struct MscBuilder : CppBuilder {

--- a/uppsrc/ide/Builders/Cocoa.cpp
+++ b/uppsrc/ide/Builders/Cocoa.cpp
@@ -1,7 +1,5 @@
 #include "Builders.h"
 
-#ifdef PLATFORM_OSX
-
 #include <Draw/Draw.h>
 #include <plugin/png/png.h>
 
@@ -53,8 +51,13 @@ void GccBuilder::CocoaAppBundle()
 			PNGEncoder().SaveFile(AppendFileName(icons, fn), Rescale(img, n, n));
 		}
 
+#ifdef PLATFORM_OSX
 		String exec = String() << "iconutil --convert icns --output \"" << icns << "\" \"" << icons << "\"";
-		Execute(exec);
+#else
+		String exec = String() << "icnsutil -c icns -o \"" << icns << "\" \"" << icons << "\"";
+#endif
+		if (Execute(exec) != 0)
+            PutConsole("Failed to create icons");
 	}
 
 	if(IsNull(Info_plist)) {
@@ -82,11 +85,12 @@ void GccBuilder::CocoaAppBundle()
 	}
 	String Info_plist_path = GetFileFolder(GetFileFolder(target)) + "/Info.plist";
 	if(LoadFile(Info_plist_path) != Info_plist) {
+#ifdef PLATFORM_OSX
 		if(FileExists(Info_plist_path))
 			Execute("defaults delete " + Info_plist_path); // Force MacOS to reload plist
+#endif
 		SaveFile(Info_plist_path, Info_plist);
 		PutConsole("Saving " << Info_plist_path);
 	}
 }
 
-#endif


### PR DESCRIPTION
This change enables cross-compilation for MacOS (OSX) using osxcross.
It is supposed that a build method will use a compiler called x86_64-apple-darwin19-clang++-libc++ (or similar).
o64-XXX compiler names are not supported.
Building of GUI apps depends on a tool called **icnsutil** which replaces the Darwin **iconutil**. (Debian/Ubuntu package **icnsutils**)