### PR TITLE
Core/SSL: MSVC aes warning fix

### DIFF
--- a/uppsrc/Core/SSL/AES.cpp
+++ b/uppsrc/Core/SSL/AES.cpp
@@ -223,7 +223,7 @@ bool Aes256Gcm::Decrypt(Stream& in, const String& password, Stream& out)
 			throw Exc("Decryption aborted");
 		
 		while(remaining > 0) {
-			int64 csz = min((int64) chunksize, remaining);
+			int64 csz = min(static_cast<int64>(chunksize), remaining);
 			String chunk = in.Get(static_cast<int>(csz)); // Chunk size is guaranteed to be smaller than INT_MAX
 			if(chunk.IsEmpty())
 				break;

--- a/uppsrc/Core/SSL/AES.cpp
+++ b/uppsrc/Core/SSL/AES.cpp
@@ -223,7 +223,8 @@ bool Aes256Gcm::Decrypt(Stream& in, const String& password, Stream& out)
 			throw Exc("Decryption aborted");
 		
 		while(remaining > 0) {
-			String chunk = in.Get(min((int64) chunksize, remaining));
+			int64 csz = min((int64) chunksize, remaining);
+			String chunk = in.Get(static_cast<int>(csz)); // Chunk size is guaranteed to be smaller than INT_MAX
 			if(chunk.IsEmpty())
 				break;
 			

--- a/uppsrc/Core/SSL/SSL.h
+++ b/uppsrc/Core/SSL/SSL.h
@@ -153,7 +153,7 @@ public:
     virtual ~Aes256Gcm();
 
     Aes256Gcm& Iteration(int n)                                         { iteration = clamp(n, AES_GCM_MIN_ITERATION, AES_GCM_MAX_ITERATION); return *this; }
-    Aes256Gcm& Chunksize(int sz)                                        { chunksize = clamp(sz, 128, INT_MAX); return *this; }
+    Aes256Gcm& ChunkSize(int sz)                                        { chunksize = clamp(sz, 128, INT_MAX); return *this; }
 
     bool Encrypt(Stream& in, const String& password, Stream& out);
     bool Encrypt(const String& in, const String& password, String& out) { return EncDec(true, in, password, out); }

--- a/uppsrc/Core/SSL/src.tpp/Upp_SSL_AES256GCM_en-us.tpp
+++ b/uppsrc/Core/SSL/src.tpp/Upp_SSL_AES256GCM_en-us.tpp
@@ -76,8 +76,8 @@ range. Default is implementation`-defined. Returns `*this for
 method chaining.&]
 [s3;%- &]
 [s4;%- &]
-[s5;:Upp`:`:Aes256Gcm`:`:Chunksize`(int`):%- Aes256Gcm[@(0.0.255) `&] 
-[* Chunksize]([@(0.0.255) int] [*@3 sz])&]
+[s5;:Upp`:`:Aes256Gcm`:`:ChunkSize`(int`):%- Aes256Gcm[@(0.0.255) `&] 
+[* ChunkSize]([@(0.0.255) int] [*@3 sz])&]
 [s2; Sets the processing chunk size (for streaming I/O) to [%-*@3 sz]. 
 Must be at least 128 bytes. Returns `*this for method chaining.&]
 [s3;%- &]


### PR DESCRIPTION
Fixes the MSVC's complaint about possible truncation and corrects a method name (Chunksize -> ChunkSize)