### PR TITLE
Fix compilation issue in CodeEditor/Style.cpp on NixOS

### DIFF
--- a/uppsrc/CodeEditor/Style.cpp
+++ b/uppsrc/CodeEditor/Style.cpp
@@ -38,7 +38,7 @@ void HighlightSetup::DefaultHlStyles()
 		WhiteTheme();
 }
 
-inline void HighlightSetup::InitOnce()
+void HighlightSetup::InitOnce()
 {
 	ONCELOCK {
 		static bool initialised;


### PR DESCRIPTION
It looks like inline in CodeEditor/Style.cpp is generating compilation error to on of our users o NixOS (https://nixos.org/).

What is worth noticing is than in .h file this function is without inline declaration - https://github.com/ultimatepp/ultimatepp/blob/522ccf5de056b44cec6840a10e571085ec53ba6a/uppsrc/CodeEditor/Syntax.h#L65.

```
		-lz -Wl,--end-group
/nix/store/wcv8n2k53w8sbffpf716gxj6mjb5jf26-binutils-2.44/bin/ld: .cache/upp.out/CodeEditor/GCC-Gcc-Gui-Linux-Posix-Shared/CodeEditor.a(CodeEditor.o): in function `Upp::CodeEditor::CodeEditor()':
CodeEditor.cpp:(.text._ZN3Upp10CodeEditorC2Ev+0x507): undefined reference to `Upp::HighlightSetup::InitOnce()'
collect2: error: ld returned 1 exit status
make: *** [Makefile:267: ide] Error 1
```