### PR TITLE
Fix MSVC linking error due to wrong titlebar global variables declaration

### DIFF
--- a/reference/CustomTitleBar/CustomTitleBar.upp
+++ b/reference/CustomTitleBar/CustomTitleBar.upp
@@ -1,3 +1,5 @@
+description "Demonstrates how to implement and use a custom title bar\377";
+
 uses
 	CtrlLib;
 

--- a/reference/CustomTitleBar/main.cpp
+++ b/reference/CustomTitleBar/main.cpp
@@ -36,7 +36,7 @@ struct MyApp : TopWindow {
 		int h = menubar.GetStdHeight();
 		CustomTitleBar(h); // h is suggested minimum height
 		
-		if(IsCustomTitleBar() && 0) {
+		if(IsCustomTitleBar()) {
 			menubar.Transparent();
 			auto cm = GetCustomTitleBarMetrics();
 			bararea.Height(cm.height);

--- a/uppsrc/CtrlCore/Win32Wnd.cpp
+++ b/uppsrc/CtrlCore/Win32Wnd.cpp
@@ -228,6 +228,9 @@ void Ctrl::InstallPanicBox()
 	InstallPanicMessageBox(&Win32PanicMessageBox);
 }
 
+extern bool is_custom_titlebar_available__;
+extern Event<const TopWindow *, TopWindow::CustomTitleBarMetrics&> custom_titlebar_metrics__;
+
 void Ctrl::InitWin32(HINSTANCE hInstance)
 {
 	GuiLock __;
@@ -289,12 +292,8 @@ void Ctrl::InitWin32(HINSTANCE hInstance)
 
 	GlobalBackPaint();
 
-	extern bool is_custom_titlebar_available__;
-	
 	is_custom_titlebar_available__ = IsWin11();
 
-	extern Event<const TopWindow *, TopWindow::CustomTitleBarMetrics&> custom_titlebar_metrics__;
-	
 	custom_titlebar_metrics__ = [=](const TopWindow *tw, TopWindow::CustomTitleBarMetrics& m) {
 		if(!tw->custom_titlebar)
 			return;


### PR DESCRIPTION
It looks like MSVC failed to link recent version of CtrlCore.