### PR TITLE
Added reset button to reference/AnimateCtrlGeometry plus changes in parameter name (duration -> duration_ms)

### DIFF
--- a/reference/AnimateCtrlGeometry/main.cpp
+++ b/reference/AnimateCtrlGeometry/main.cpp
@@ -5,26 +5,50 @@ using namespace Upp;
 struct AnimateCtrlGeometry : TopWindow {
 	Array<ColorPusher> pushers;
 	Vector<Ptr<Ctrl>>  ctrls;
+	Rect               ctrls_start_rect;
 	Vector<Rect>       targets;
-
+	Button             reset;
+	
 	AnimateCtrlGeometry()
+		: ctrls_start_rect(Rect(0, 0, 100, 100))
 	{
 		Title("Ctrl geometry animation");
 		
-		CenterScreen().SetRect(0,0, 400, 200);
+		CenterScreen().SetRect(0,0, 400, 230);
+		
+		Add(reset.SetLabel("Reset").HSizePosZ(4, 4).BottomPosZ(4, 20));
+		reset.WhenAction = [&] { Reset(); };
 
 		for(int row = 0; row < 2; row++) {
 			for(int col = 0; col < 4; col++) {
 				ColorPusher& bt = pushers.Add();
 				bt <<= Color(Random(256), Random(256), Random(256));
-				bt.SetRect(0, 0, 100, 100);
+				bt.SetRect(ctrls_start_rect);
 				Add(bt);
 				ctrls.Add(&bt);
 				targets.Add(RectC(col * 100, row * 100, 100, 100).Deflated(2));
 			}
 		}
 		
-		SetTimeCallback(1000, [&]{ Animate(ctrls, targets, 300); });
+		ScheduleAnimation();
+	}
+	
+	void ScheduleAnimation()
+	{
+		constexpr int LAUNCH_DELAY_MS = 1000;
+		constexpr int DURATION_MS = 300;
+		
+		reset.Disable();
+		SetTimeCallback(LAUNCH_DELAY_MS, [=] {
+			Animate(ctrls, targets, DURATION_MS); reset.Enable();
+		});
+	}
+	
+	void Reset()
+	{
+		for (ColorPusher& cp : pushers)
+			cp.SetRect(ctrls_start_rect);
+		ScheduleAnimation();
 	}
 };
 

--- a/uppsrc/CtrlCore/src.tpp/Animation_en-us.tpp
+++ b/uppsrc/CtrlCore/src.tpp/Animation_en-us.tpp
@@ -31,20 +31,20 @@ rectangle without any animation.&]
 [s3; &]
 [s4; &]
 [s5;:Upp`:`:Animate`(Event`,int`): [@(0.0.255) void] [* Animate](Event<[@(0.0.255) double]>
- [*@3 update], [@(0.0.255) int] [*@3 duration] [@(0.0.255) `=] [@3 100])&]
+ [*@3 update], [@(0.0.255) int] [*@3 duration`_ms] [@(0.0.255) `=] [@3 100])&]
 [s2;%% Performs GUI animation, repeatedly calling [%-*@3 update] with 
-increasing numbers from the interval 0..1 for [%-*@3 duration] 
+increasing numbers from the interval 0..1 for [%- duration] in 
 milliseconds.&]
 [s3; &]
 [s4; &]
 [s5;:Upp`:`:Animate`(Vector`&`,const Vector`&`,int`): [@(0.0.255) void] 
 [* Animate](Vector<Ptr<Ctrl>>[@(0.0.255) `&] [*@3 ctrls], [@(0.0.255) const] 
-Vector<Rect>[@(0.0.255) `&] [*@3 targets], [@(0.0.255) int] [*@3 duration] 
+Vector<Rect>[@(0.0.255) `&] [*@3 targets], [@(0.0.255) int] [*@3 duration`_ms] 
 [@(0.0.255) `=] [@3 100])&]
 [s2;%% Animates the transition of multiple [%-*@3 ctrls] from their 
 current positions to the target positions specified by the [%-*@3 targets] 
 parameter, over a given [%-*@3 duration]. The default duration 
-is 100 miliseconds. The number of ctrls must match the number 
+is 100 milliseconds. The number of ctrls must match the number 
 of the target rectangles otherwise the function will silently 
 return without modifying anything.&]
 [s3; &]
@@ -53,12 +53,12 @@ return without modifying anything.&]
 <[@(0.0.255) class] T>&]
 [s5;:Upp`:`:Animate`(Vector`&`,const Vector`&`,Event`,int`): [@(0.0.255) void] 
 [* Animate](Vector<T>[@(0.0.255) `&] [*@3 data], [@(0.0.255) const] Vector<T>[@(0.0.255) `&
-] [*@3 targets], Event<> [*@3 update], [@(0.0.255) int] [*@3 duration] 
+] [*@3 targets], Event<> [*@3 update], [@(0.0.255) int] [*@3 duration`_ms] 
 [@(0.0.255) `=] [@3 100])&]
 [s2;%% Animates the transition of multiple [%-*@3 data] values from 
 their current positions to the target positions specified by 
 the [%-*@3 targets] parameter, over a given [%-*@3 duration]. The 
-default duration is 100 miliseconds. The number of [%-*@3 data] 
+default duration is 100 milliseconds. The number of [%-*@3 data] 
 values must match the number of the [%-*@3 targets ]values otherwise 
 the function will silently return without modifying anything. 
 After each animation step Animate calls [%-*@3 update].&]

--- a/uppsrc/CtrlLib/CtrlUtil.cpp
+++ b/uppsrc/CtrlLib/CtrlUtil.cpp
@@ -55,17 +55,17 @@ void Animate(Ctrl& c, int x, int y, int cx, int cy, int type)
 	Animate(c, RectC(x, y, cx, cy), type);
 }
 
-void Animate(Event<double> update, int duration)
+void Animate(Event<double> update, int duration_ms)
 {
-	if(duration < 1)
+	if(duration_ms < 1)
 		return;
 
 	int start = msecs();
 	for(;;) {
         int elapsed = msecs() - start;
-        if(elapsed > duration)
+        if(elapsed > duration_ms)
             break;
-        double t = min(1.0, (double) elapsed / (double) duration);
+        double t = min(1.0, (double) elapsed / (double) duration_ms);
         t = t * t * (3 - 2 * t);  // Ease-in-out (smoother movement).
         update(t);
         Ctrl::ProcessEvents();
@@ -74,7 +74,7 @@ void Animate(Event<double> update, int duration)
     update(1);
 }
 
-void Animate(Vector<Ptr<Ctrl>>& ctrls, const Vector<Rect>& targets, int duration)
+void Animate(Vector<Ptr<Ctrl>>& ctrls, const Vector<Rect>& targets, int duration_ms)
 {
 	Vector<Rect> data;
 	for(const Ptr<Ctrl>& c : ctrls)
@@ -84,7 +84,7 @@ void Animate(Vector<Ptr<Ctrl>>& ctrls, const Vector<Rect>& targets, int duration
 		for(int i = 0; i < ctrls.GetCount(); i++)
 			if(ctrls[i])
 				ctrls[i]->SetRect(data[i]);
-	}, duration);
+	}, duration_ms);
 }
 
 bool CtrlLibDisplayError(const Value& e) {


### PR DESCRIPTION
The changes introduced in this PR improves CtrlLib animations by:
- Adding reset button to reference/AnimateCtrlGeometry, it was annoying to relaunch the reference app to see the animation again
- Change the animate function parameter name duration to duration_ms. Thanks to that the signature should be easier to understand, also it is aligned with SetTimeCallback declaration.
- Docs has been updated accordingly to changes in Animate function parameter names