### PR TITLE
CodeEditor: Remove "thread" as C++ keyword

### DIFF
--- a/uppsrc/CodeEditor/CInit.cpp
+++ b/uppsrc/CodeEditor/CInit.cpp
@@ -38,7 +38,7 @@ void CSyntax::InitKeywords()
         "operator", "or", "or_eq", "override", "private", "protected",
         "public", "register", "reinterpret_cast", "requires",
         "short", "signed", "sizeof", "static", "static_assert",
-        "static_cast", "struct", "switch", "template", "this", "thread",
+        "static_cast", "struct", "switch", "template", "this",
         "thread_local", "true", "try", "typedef", "typeid",
         "typename", "union", "unsigned", "using", "virtual",
         "void", "volatile", "wchar_t", "while", "xor", "xor_eq",


### PR DESCRIPTION
It looks like thread is not c++ keyword. Leaving it as it is might be confusing especially when you are using std::thread.

std::thread shouldn't be higlighted, in current implementation it is.

Source: https://en.cppreference.com/w/cpp/keywords.html