### PR TITLE
Fix to compile on MSVC 17.14.7

### DIFF
--- a/uppsrc/ide/Android/AndroidNDK.cpp
+++ b/uppsrc/ide/Android/AndroidNDK.cpp
@@ -38,7 +38,7 @@ String AndroidNDK::FindDefaultPlatform() const
 	Sort(platforms, StdGreater<String>());
 	Android::RemoveVersionsNormalization(platforms);
 	
-	return !platforms.IsEmpty() ? platforms[0] : "";
+	return !platforms.IsEmpty() ? platforms[0] : String();
 }
 
 String AndroidNDK::FindDefaultToolchain() const
@@ -51,7 +51,7 @@ String AndroidNDK::FindDefaultToolchain() const
 	}
 	
 	SortIndex(toolchains, StdGreater<String>());
-	return !toolchains.IsEmpty() ? toolchains[toolchains.GetCount()] : "";
+	return !toolchains.IsEmpty() ? toolchains[toolchains.GetCount()] : String();
 }
 
 String AndroidNDK::FindDefaultCppRuntime() const
@@ -116,7 +116,7 @@ String AndroidNDK::GetIncludeDir() const
 	dir << "arch-arm" << DIR_SEPS;
 	dir << "usr" << DIR_SEPS << "include";
 	
-	return DirectoryExists(dir) ? dir : "";
+	return DirectoryExists(dir) ? dir : String();
 }
 
 String AndroidNDK::GetCppIncludeDir(const String& cppRuntime) const

--- a/uppsrc/ide/Assist.cpp
+++ b/uppsrc/ide/Assist.cpp
@@ -752,7 +752,7 @@ void AssistEditor::Assist(bool macros)
 					AssistItem& f = assist_item.Add();
 					(AutoCompleteItem&)f = m;
 					f.uname = ToUpper(f.name);
-					f.typei = assist_type.FindAdd(f.kind == CXCursor_MacroDefinition ? "<macros>" : f.parent);
+					f.typei = assist_type.FindAdd(f.kind == CXCursor_MacroDefinition ? String("<macros>") : f.parent);
 				}
 			PopUpAssist();
 		});

--- a/uppsrc/ide/Builders/MakeFile.cpp
+++ b/uppsrc/ide/Builders/MakeFile.cpp
@@ -318,7 +318,7 @@ void MakeBuild::SaveMakeFile(const String& fn, bool exporting)
 	inclist << " -I$(UPPOUT)"; // build_info.h is created there
 
 	makefile << "\n"
-		"UPPOUT = " << (exporting ? "_out/" : GetMakePath(AdjustMakePath(AppendFileName(uppout, String())), win32)) << "\n"
+		"UPPOUT = " << (exporting ? String("_out/") : GetMakePath(AdjustMakePath(AppendFileName(uppout, String())), win32)) << "\n"
 		"CINC   = " << inclist << "\n"
 		"Macro  = ";
 

--- a/uppsrc/ide/Core/Util.cpp
+++ b/uppsrc/ide/Core/Util.cpp
@@ -32,7 +32,7 @@ String GetGitPath()
 	static String path;
 	ONCELOCK {
 		path = AppendFileName(GetExeFolder(), "\\bin\\mingit\\cmd\\git.exe");
-		path = FileExists(path) ? "\"" + path + "\"" : "git";
+		path = FileExists(path) ? String("\"") + path + "\"" : String("git");
 	}
 	return path;
 #else

--- a/uppsrc/ide/Debuggers/Pretty.cpp
+++ b/uppsrc/ide/Debuggers/Pretty.cpp
@@ -114,7 +114,7 @@ bool Pdb::VisualisePretty(Visual& result, Pdb::Val val, dword flags)
 {
 	auto ResultCount = [&](int64 count) {
 		result.Cat("[", SLtBlue);
-		result.Cat(count == INT64_MAX ? ">10000" : AsString(count), SRed);
+		result.Cat(count == INT64_MAX ? String(">10000") : AsString(count), SRed);
 		result.Cat("] ", SLtBlue);
 	};
 	

--- a/uppsrc/ide/LayDes/fontprop.cpp
+++ b/uppsrc/ide/LayDes/fontprop.cpp
@@ -19,7 +19,7 @@ String FormatFont(Font font)
 		txt << (h ? "StdFontZ" : "StdFont");
 		break;
 	}
-	txt << '(' << (h ? Format("%d)", h) : ")");
+	txt << "(" << (h ? Format("%d)", h) : String(")"));
 	if(font.IsBold())
 		txt << ".Bold()";
 	if(font.IsItalic())

--- a/uppsrc/ide/LayDes/property.cpp
+++ b/uppsrc/ide/LayDes/property.cpp
@@ -124,7 +124,7 @@ struct IntProperty : public EditorProperty<EditInt> {
 	}
 	virtual String Save() const {
 		int q = ~editor;
-		return IsNull(q) ? "Null" : AsString(q);
+		return IsNull(q) ? String("Null") : AsString(q);
 	}
 
 	static ItemProperty *Create() { return new IntProperty; }

--- a/uppsrc/ide/MacroManager/UscFileParser.cpp
+++ b/uppsrc/ide/MacroManager/UscFileParser.cpp
@@ -79,14 +79,14 @@ void UscFileParser::ReadMacro(CParser& parser, const String& comment, const char
 		FindNextElement(parser);
 		return;
 	}
-	macro.name = String() << (parser.IsString() ? parser.ReadString() : "");
+	macro.name = String() << (parser.IsString() ? parser.ReadString() : String());
 	if(parser.Char(':')) {
 		if(!parser.IsString()) {
 			FindNextElement(parser);
 			return;
 		}
 
-		macro.name << " : " << (parser.IsString() ? parser.ReadString() : "");
+		macro.name << " : " << (parser.IsString() ? parser.ReadString() : String());
 	}
 	if (!parser.IsChar('{'))
 		ReadKeyDesc(parser);

--- a/uppsrc/ide/Methods.cpp
+++ b/uppsrc/ide/Methods.cpp
@@ -602,7 +602,7 @@ String BuildMethods::GetSetupPrefix(const String& setupKey) const
 
 String BuildMethods::GetSetupPrefix(const Index<String>& buildersGroup) const
 {
-	return buildersGroup.GetCount() ? GetSetupPrefix(buildersGroup[0]) : "";
+	return buildersGroup.GetCount() ? GetSetupPrefix(buildersGroup[0]) : String();
 }
 
 void BuildMethods::InitSetups()

--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -371,7 +371,7 @@ void UppHubDlg::Sync()
 	}
 	else {
 		qtf << "[* \1" << n->description << "\1]";
-		qtf << (loading ? "&[/ Loading more information]" : "&[/ Failed to get ]\1" + n->readme);
+		qtf << (loading ? String("&[/ Loading more information]") : String("&[/ Failed to get ]\1") + n->readme);
 	}
 	info <<= qtf;
 }

--- a/uppsrc/ide/clang/Visitor.cpp
+++ b/uppsrc/ide/clang/Visitor.cpp
@@ -332,7 +332,7 @@ bool ClangVisitor::ProcessNode(CXCursor cursor)
 		}
 		else {
 			static String op = "operator";
-			int q = FindId(r.id, r.kind == CXCursor_ConversionFunction ? "operator" : r.name);
+			int q = FindId(r.id, r.kind == CXCursor_ConversionFunction ? String("operator") : r.name);
 			if(q >= 0) {
 				r.nest = r.id.Mid(0, q);
 				r.nest.TrimEnd("::");


### PR DESCRIPTION
It looks like something changed in the latest version of MSVC. Now there is a compilation error in teneray operation and strings. It might be bug in the compiler since this code compiles well for ages and there is no issue at all on other compilers.

The good news is that the fixed code is compatible with other compilers, too.