### PR TITLE
Fix warning with lambda captuer mplicit capture of 'this' with a capture default of '=' for Gui01 (c++20 and above)

### DIFF
--- a/uppsrc/Core/CoWork.h
+++ b/uppsrc/Core/CoWork.h
@@ -183,7 +183,7 @@ class AsyncWork {
 		Ret2   ret;
 	
 		template<class Function, class... Args>
-		void        Do(Function&& f, Args&&... args) { co.Do([=]() { ret = f(args...); }); }
+		void        Do(Function&& f, Args&&... args) { co.Do([=, this]() { ret = f(args...); }); }
 		const Ret2& Get()                            { return ret; }
 		Ret2        Pick()                           { return pick(ret); }
 	};

--- a/uppsrc/Core/CoWork.h
+++ b/uppsrc/Core/CoWork.h
@@ -183,7 +183,7 @@ class AsyncWork {
 		Ret2   ret;
 	
 		template<class Function, class... Args>
-		void        Do(Function&& f, Args&&... args) { co.Do([=, this]() { ret = f(args...); }); }
+		void        Do(Function&& f, Args&&... args) { co.Do([=, *this]() { ret = f(args...); }); }
 		const Ret2& Get()                            { return ret; }
 		Ret2        Pick()                           { return pick(ret); }
 	};

--- a/uppsrc/Core/FilterStream.h
+++ b/uppsrc/Core/FilterStream.h
@@ -36,7 +36,7 @@ public:
 	void Set(Stream& in_, F& filter) {
 		Init();
 		in = &in_;
-		filter.WhenOut = [=](const void *ptr, int size) { Out(ptr, size); };
+		filter.WhenOut = [this](const void *ptr, int size) { Out(ptr, size); };
 		Filter = [&filter](const void *ptr, int size) { filter.Put(ptr, size); };
 		End = [&filter] { filter.End(); };
 	}

--- a/uppsrc/Core/Function.h
+++ b/uppsrc/Core/Function.h
@@ -71,7 +71,7 @@ public:
 	Function(Function&& src)                   { Pick(pick(src)); }
 	Function& operator=(Function&& src)        { if(&src != this) { Free(ptr); ptr = src.ptr; src.ptr = NULL; } return *this; }
 	
-	Function Proxy() const                     { return [=] (ArgTypes... args) { return (*this)(args...); }; }
+	Function Proxy() const                     { return [this] (ArgTypes... args) { return (*this)(args...); }; }
 
 	template <class F>
 	Function& operator<<(F fn)                 { if(!ptr) { Pick(pick(fn)); return *this; }

--- a/uppsrc/CtrlLib/ColorPopup.cpp
+++ b/uppsrc/CtrlLib/ColorPopup.cpp
@@ -435,7 +435,7 @@ ColorPopUp::ColorPopUp()
 	voidtext = t_("(none)");
 	
 	settext.SetImage(CtrlImg::color_edit());
-	settext << [=] {
+	settext << [this] {
 		String text;
 		if(!IsNull(color) && color != VoidColor())
 			text = ColorToHtml(color);

--- a/uppsrc/CtrlLib/CtrlUtil.cpp
+++ b/uppsrc/CtrlLib/CtrlUtil.cpp
@@ -402,11 +402,12 @@ void MemoryProfileInfo() {
 };
 
 FileSelButton::FileSelButton(MODE mode, const char *title)
-: title(title), mode(mode)
+	: title(title)
+	, mode(mode)
 {
 	button.NoWantFocus();
 	button.SetImage(mode == MODE_DIR ? CtrlImg::DirSmall() : CtrlImg::FileSmall());
-	button << [=] { OnAction(); };
+	button << [this] { OnAction(); };
 }
 
 void FileSelButton::Attach(Ctrl& parent)

--- a/uppsrc/CtrlLib/DateTimeCtrl.h
+++ b/uppsrc/CtrlLib/DateTimeCtrl.h
@@ -513,7 +513,7 @@ public:
 		cc.clock      <<= THISBACK(OnClockChoice);
 		cc.WhenPopDown  = THISBACK(OnClose);
 		cc.calendar.WhenSelect = WhenSelect.Proxy();
-		this->WhenPaper = [=](Color c) {
+		this->WhenPaper = [this](Color c) {
 			drop.SetPaper(c);
 		};
 	}

--- a/uppsrc/CtrlLib/DropChoice.cpp
+++ b/uppsrc/CtrlLib/DropChoice.cpp
@@ -6,7 +6,7 @@ DropChoice::DropChoice() {
 	always_drop = hide_drop = false;
 	AddButton().Main() <<= THISBACK(Drop);
 	NoDisplay();
-	list.WhenSelect = [=] { Select(); };
+	list.WhenSelect = [this] { Select(); };
 	dropfocus = true;
 	EnableDrop(false);
 	dropwidth = 0;
@@ -21,7 +21,7 @@ void DropChoice::AddTo(Ctrl& _owner)
 	owner = &_owner;
 
 	if(auto *ef = dynamic_cast<EditField *>(owner))
-		ef->WhenPaper = [=](Color c) { MultiButtonFrame::SetPaper(c); };
+		ef->WhenPaper = [this](Color c) { MultiButtonFrame::SetPaper(c); };
 }
 
 void DropChoice::EnableDrop(bool b)

--- a/uppsrc/CtrlLib/Help.cpp
+++ b/uppsrc/CtrlLib/Help.cpp
@@ -38,7 +38,7 @@ bool HelpWindow::GoTo0(const String& link)
 	}
 	if(WhenMatchLabel) {
 		WString lw = label.ToWString();
-		return view.GotoLabel([=](const WString& data) { return WhenMatchLabel(data, lw); }, true, true) || lnk;
+		return view.GotoLabel([this, lw](const WString& data) { return WhenMatchLabel(data, lw); }, true, true) || lnk;
 	}
 	return view.GotoLabel(label, true, true) || lnk;
 }
@@ -324,7 +324,7 @@ HelpWindow::HelpWindow()
 	Sizeable().Zoomable();
 	Title(t_("Help"));
 	BackPaint();
-	view.WhenLink = [=](const String& h) { GoTo(h); };
+	view.WhenLink = [this](const String& h) { GoTo(h); };
 	AddFrame(toolbar);
 	view.SetZoom(Zoom(1, 1));
 	zoom.m = 160;
@@ -337,7 +337,7 @@ HelpWindow::HelpWindow()
 	SetBar();
 	tree.BackPaint();
 	view.BackPaintHint();
-	view.WhenMouseWheel = [=] (int zdelta, dword keyflags) {
+	view.WhenMouseWheel = [this] (int zdelta, dword keyflags) {
 		if(keyflags & K_CTRL) {
 			zoom.m = clamp((zoom.m / 5 + sgn(zdelta)) * 5, 60, 600);
 			SetZoom();

--- a/uppsrc/CtrlLib/MultiButton.cpp
+++ b/uppsrc/CtrlLib/MultiButton.cpp
@@ -118,7 +118,7 @@ void MultiButton::MultiButtons()
 	if(droppush) {
 		SubButton& b = buttons.Add();
 		b.owner = this;
-		b.WhenPush = [=] { DropPush(); };
+		b.WhenPush = [this] { DropPush(); };
 		b.main = true;
 		droppush = false;
 	}

--- a/uppsrc/CtrlLib/Text.cpp
+++ b/uppsrc/CtrlLib/Text.cpp
@@ -376,7 +376,7 @@ void TextCtrl::ViewLoading()
 		
 		if(msecs(start) > 20) {
 			view_loading_pos = view->GetPos();
-			PostCallback([=] { ViewLoading(); });
+			PostCallback([this] { ViewLoading(); });
 			WhenViewMapping(view_loading_pos);
 			break;
 		}

--- a/uppsrc/Painter/Render.cpp
+++ b/uppsrc/Painter/Render.cpp
@@ -360,7 +360,7 @@ void BufferPainter::FinishPathJob()
 	fillcount = jobcount;
 	Swap(cofill, cojob); // Swap to keep allocated rasters (instead of pick)
 	
-	fill_job & [=] {
+	fill_job & [this] {
 		PAINTER_TIMING("CO FILL JOB");
 		int miny = ip->GetHeight() - 1;
 		int maxy = 0;


### PR DESCRIPTION
It looks like fixing the issue with deprecation of capturing this with [=] won't be that difficult. I just wanted to start the whole process. I fixed this warning for Gui01 tutorail and associated pacakges, so right now while compiling Gui01 example with std=c++20 and above there shouldn't be following warning:
`C:\Prototable\upp\git\uppsrc\CtrlLib\CtrlUtil.cpp (410): warning: implicit capture of 'this' with a capture default of '=' is deprecated [-Wdeprecated-this-capture]`

Also, I think the code is batter, because we are capturing variables we don't want to. I suggest making this kind of changes in chunks. At some point of time, we will eliminate all warnings of that kind.

I would like to add that maybe we might do not like the new syntax and it is longer to what we had in the past. But, the overall solution is batter, especially when you capture [this] instead of [=]. In this case the local variables are not copied. In the end we shouldn't consider silencing this warning. Also, at some point it might be a compilation error, so we will be forced to fix it.

--------------------------------
The next step would be to fix all Gui* tutorials. After that we can jump to other places like ide.