### PR TITLE
Ide: show git errors when update of UppHub packages failed

### DIFF
--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -540,11 +540,18 @@ void UppHubDlg::Update()
 	if(!PromptYesNo("Pull updates for all modules?"))
 		return;
 	UrepoConsole console;
+	
+	bool errors = false;
 	for(const UppHubNest& n : upv) {
 		String dir = GetHubDir() + "/" + n.name;
-		if(DirectoryExists(dir))
-			console.Git(dir, "pull --rebase");
+		if(!DirectoryExists(dir))
+			continue;
+		
+		if (console.Git(dir, "pull --rebase") != 0)
+			errors = true;
 	}
+	if (errors)
+		console.Perform();
 }
 
 void UppHubDlg::Install(const Index<String>& ii_)

--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -541,19 +541,19 @@ void UppHubDlg::Update()
 		return;
 	UrepoConsole console;
 
-	bool errors = false;
+	int errors = 0;
 	for(const UppHubNest& n : upv) {
 		String dir = GetHubDir() + "/" + n.name;
 		if(!DirectoryExists(dir))
 			continue;
 
 		if(console.Git(dir, "pull --rebase") != 0)
-			errors = true;
+			++errors;
 	}
-	if(!errors)
+	if(errors == 0)
 		return;
 	
-	ErrorOK("Update failed. Review the logs to diagnose and resolve the issues.");
+	ErrorOK(Format("Update failed (%d errors). Review the logs to diagnose and resolve the issues.", errors));
 	console.Perform();
 }
 

--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -552,8 +552,10 @@ void UppHubDlg::Update()
 	}
 	if(errors == 0)
 		return;
-	
-	ErrorOK(Format("Update failed (%d errors). Review the logs to diagnose and resolve the issues.", errors));
+
+	ErrorOK(
+		Format("Update failed (%d errors). Review the logs to diagnose and resolve the issues.",
+	           errors));
 	console.Perform();
 }
 

--- a/uppsrc/ide/UppHub.cpp
+++ b/uppsrc/ide/UppHub.cpp
@@ -540,18 +540,21 @@ void UppHubDlg::Update()
 	if(!PromptYesNo("Pull updates for all modules?"))
 		return;
 	UrepoConsole console;
-	
+
 	bool errors = false;
 	for(const UppHubNest& n : upv) {
 		String dir = GetHubDir() + "/" + n.name;
 		if(!DirectoryExists(dir))
 			continue;
-		
-		if (console.Git(dir, "pull --rebase") != 0)
+
+		if(console.Git(dir, "pull --rebase") != 0)
 			errors = true;
 	}
-	if (errors)
-		console.Perform();
+	if(!errors)
+		return;
+	
+	ErrorOK("Update failed. Review the logs to diagnose and resolve the issues.");
+	console.Perform();
 }
 
 void UppHubDlg::Install(const Index<String>& ii_)

--- a/uppsrc/ide/urepo.h
+++ b/uppsrc/ide/urepo.h
@@ -2,8 +2,6 @@
 #include <CtrlCore/lay.h>
 
 class UrepoConsole : public WithUrepoConsoleLayout<TopWindow> {
-	typedef UrepoConsole CLASSNAME;
-	
 	Font font;
 	void AddResult(const String& out);
 	bool canceled = false;


### PR DESCRIPTION
Currently there are no information when UppHub "Update all" operation ended with failures. It closes immediately and user are not aware about the problems. This PR is suppose to address this problem. 