### PR TITLE
CtrlCore: Fix VirtualGui compilation on Windows.

### DIFF
--- a/uppsrc/CtrlCore/CtrlDraw.cpp
+++ b/uppsrc/CtrlCore/CtrlDraw.cpp
@@ -414,11 +414,11 @@ void Ctrl::UpdateArea0(SystemDraw& draw, const Rect& clip, int backpaint)
 	LLOG("========== UPDATE AREA " << UPP::Name(this) << ", clip: " << clip << " ==========");
 	ExcludeDHCtrls(draw, GetRect().GetSize(), clip);
 	auto DoCtrlPaint = [&](SystemDraw& w, const Rect& clip) {
-	#ifdef PLATFORM_WIN32
+	#if defined(PLATFORM_WIN32) && !defined(VIRTUALGUI)
 		PaintWinBarBackground(w, clip);
 	#endif
 		CtrlPaint(w, clip);
-	#ifdef PLATFORM_WIN32
+	#if defined(PLATFORM_WIN32) && !defined(VIRTUALGUI)
 		PaintWinBar(w, clip);
 	#endif
 	};


### PR DESCRIPTION
This PR aims to fix virtualgui compilation error on Windows (due to the WinBar support).

Please review.