### PR TITLE
Implement ${METHOD_DIR} recognition in umk

### DIFF
--- a/uppsrc/umk/umake.cpp
+++ b/uppsrc/umk/umake.cpp
@@ -38,10 +38,28 @@ String Ide::GetDefaultMethod()
 	return "GCC";
 }
 
+String ReplaceMethodDir(String paths, const String& method_dir)
+{
+	constexpr const char* METHOD_DIR = "${METHOD_DIR}";
+	
+	if (paths.Find(METHOD_DIR) == -1) {
+		return paths;
+	}
+	paths.Replace(METHOD_DIR, method_dir);
+	return paths;
+}
+
 VectorMap<String, String> Ide::GetMethodVars(const String& method)
 {
 	VectorMap<String, String> map;
 	LoadVarFile(GetMethodName(method), map);
+	
+	const String method_dir = GetFileFolder(method);
+	const Vector<String> categories_with_method_dir = {"PATH", "INCLUDE", "LIB" };
+	for (const auto& category : categories_with_method_dir) {
+		map.GetAdd(category) = ReplaceMethodDir(map.Get(category), method_dir);
+	}
+
 	return map;
 }
 


### PR DESCRIPTION
Thanks to that change we will be able to bundle umk with toolchain on Windows and distribute such package. Thanks to that it will open the possibilities of build many packages including these from UppHub directly from the terminal.

Here is the sample build method for CLANG on Windows that will be handled correctly after these changes:
```
PATH = "${METHOD_DIR}\\bin\\clang\\bin;${METHOD_DIR}\\bin\\clang\\x86_64-w64-mingw32\\bin;${METHOD_DIR}\\bin\\SDL2\\lib\\x64;${METHOD_DIR}\\bin\\pgsql\\x64\\bin;${METHOD_DIR}\\bin\\mysql\\lib64";
INCLUDE = "${METHOD_DIR}\\bin\\SDL2\\include;${METHOD_DIR}\\bin\\pgsql\\x64\\include;${METHOD_DIR}\\bin\\mysql\\include;${METHOD_DIR}\\bin\\llvm";
LIB = "${METHOD_DIR}\\bin\\SDL2\\lib\\x64;${METHOD_DIR}\\bin\\pgsql\\x64\\lib;${METHOD_DIR}\\bin\\mysql\\lib64;${METHOD_DIR}\\bin\\llvm";
```

The umk Windows package will looks as follow
<img width="720" height="282" alt="Zrzut ekranu 2025-10-11 184617" src="https://github.com/user-attachments/assets/16671570-d96d-4a9e-9e9d-c7008392f701" />
In above image bin folder has exactly the same content as bin directory in regular Windows U++ distribution.
