### PR TITLE
Eliminate crash in Ctrl::GetOwner() when short live popup is being displayed

### DIFF
--- a/uppsrc/CtrlCore/GtkWnd.cpp
+++ b/uppsrc/CtrlCore/GtkWnd.cpp
@@ -122,9 +122,7 @@ Ctrl *Ctrl::GetOwner()
 {
 	GuiLock __;
 	Top *top = GetTop();
-	if(!top)
-		return nullptr;
-	return IsOpen() ? top->owner : nullptr;
+	return top && IsOpen() ? top->owner : nullptr;
 }
 
 Ctrl *Ctrl::GetActiveCtrl()
@@ -606,3 +604,4 @@ Vector<WString> SplitCmdLine__(const char *cmd)
 
 
 #endif
+

--- a/uppsrc/CtrlCore/GtkWnd.cpp
+++ b/uppsrc/CtrlCore/GtkWnd.cpp
@@ -122,7 +122,9 @@ Ctrl *Ctrl::GetOwner()
 {
 	GuiLock __;
 	Top *top = GetTop();
-	return IsOpen() ? top->owner : NULL;
+	if(!top)
+		return nullptr;
+	return IsOpen() ? top->owner : nullptr;
 }
 
 Ctrl *Ctrl::GetActiveCtrl()
@@ -601,5 +603,6 @@ Vector<WString> SplitCmdLine__(const char *cmd)
 }
 
 }
+
 
 #endif


### PR DESCRIPTION
Latest version of U++ on Gtk crashes when hover on element that needs to be expanded via tool-tip to display full content. This PR is fixing this problem.