### PR TITLE
Removed using namespace Upp from SIMD_NEON.h

### DIFF
--- a/uppsrc/Core/SIMD_NEON.h
+++ b/uppsrc/Core/SIMD_NEON.h
@@ -1,7 +1,5 @@
 #include <arm_neon.h>
 
-using namespace Upp;
-
 force_inline
 uint64 cmask16__(uint16x8_t mask) {
 	uint8x8_t res = vshrn_n_u16(mask, 4);
@@ -284,3 +282,4 @@ force_inline i16x8 BroadcastLH3(i16x8 a)          {
 }
 
 force_inline i16x8 i64all(qword data)             { return vreinterpretq_s16_u64(vdupq_n_u64(data)); }
+


### PR DESCRIPTION
Obvious problem since this file is currently under Upp namespace. Also, it polutes all files that include Core/Core.h.