### PR TITLE
Core, CtrlLib, RichEdit, ide: Fix warnigns on macOS.

### DIFF
--- a/uppsrc/Core/SSL/AES.cpp
+++ b/uppsrc/Core/SSL/AES.cpp
@@ -18,10 +18,10 @@ namespace {
 }
 
 Aes256Gcm::Aes256Gcm()
-: iteration(AES_GCM_DEFAULT_ITERATION)
-, chunksize(1024)
-, ctx(nullptr)
+: ctx(nullptr)
 , cipher(nullptr)
+, chunksize(1024)
+, iteration(AES_GCM_DEFAULT_ITERATION)
 {
 	SslInitThread();
 	

--- a/uppsrc/CtrlLib/BeginnerInfo.cpp
+++ b/uppsrc/CtrlLib/BeginnerInfo.cpp
@@ -70,12 +70,6 @@ void PaintBasicHints(Ctrl *ctrl, Draw& w, const Rect& cr, const char *qtf, const
 		r.tm = msecs();
 	}
 
-	typedef bool (*MouseHook)(Ctrl *ctrl, bool inframe, int event, Point p,
-	                          int zdelta, dword keyflags);
-	typedef bool (*KeyHook)(Ctrl *ctrl, dword key, int count);
-	typedef bool (*StateHook)(Ctrl *ctrl, int reason);
-	typedef void (*PaintHook)(Ctrl *ctrl, Draw& draw, const Rect& clip);
-	
 	static auto Stop = [](bool testmousepos = false) {
 		int tm = msecs();
 		Point mousepos;

--- a/uppsrc/RichEdit/DiagramEditor.h
+++ b/uppsrc/RichEdit/DiagramEditor.h
@@ -64,6 +64,8 @@ public:
 private:
 	struct DropColumns : public MultiButton, public Display {
 		ColumnPopUp popup;
+		
+		using MultiButton::Paint;
 		void Paint(Draw& w, const Rect& r, const Value& q, Color ink, Color paper, dword style) const override;
 		
 		DropColumns();

--- a/uppsrc/RichEdit/DiagramRight.cpp
+++ b/uppsrc/RichEdit/DiagramRight.cpp
@@ -78,14 +78,9 @@ void DiagramEditor::RightDown(Point p, dword keyflags)
 		mdata = LoadFile(path);
 		if(IsNull(mdata))
 			return;
-		bool loaded = false;
-		if(IsSVG(mdata)) {
-			loaded = true;
-		}
-		else {
+		if(!IsSVG(mdata)) {
 			StringStream ss(mdata);
 			One<StreamRaster> r = StreamRaster::OpenAny(ss);
-			loaded = true;
 		}
 		if(IsNull(size)) {
 			Exclamation(t_("Unsupported image format."));

--- a/uppsrc/ide/Core/PPinfo.cpp
+++ b/uppsrc/ide/Core/PPinfo.cpp
@@ -80,7 +80,6 @@ void PPInfo::PPFile::Parse(Stream& in)
 	guarded = false;
 	blitz = AUTO;
 
-	int  linei = 0;
 	bool incomment = false;
 	
 	String guard_id;
@@ -120,7 +119,6 @@ void PPInfo::PPFile::Parse(Stream& in)
 	
 		while(*l.Last() == '\\' && !in.IsEof()) {
 			l.TrimLast();
-			linei++;
 			l.Cat(in.GetLine());
 		}
 	
@@ -197,14 +195,13 @@ void PPInfo::PPFile::Parse(Stream& in)
 			}
 		}
 		catch(...) {}
-		if(first)
+		if(first) {
 			for(char s : l)
 				if(s != ' ' && s != '\t') {
 					first = false;
 					break;
 				}
-		
-		linei++;
+		}
 	}
 }
 


### PR DESCRIPTION
Cleaned up various warnings across the macOS build. Three specific warnings regarding deprecated native functions remain outstanding and will be fixed later.