### PR TITLE
CtrlCore: Fix problem with ghost windows in mission control.

### DIFF
--- a/uppsrc/CtrlCore/CocoWin.mm
+++ b/uppsrc/CtrlCore/CocoWin.mm
@@ -157,9 +157,16 @@ void Ctrl::WndDestroy()
 		return;
 	bool focus = HasFocusDeep();
 	Ptr<Ctrl> owner = GetOwner();
-	[GetTop()->coco->window close];
-	delete GetTop()->coco;
+
+	auto* coco = GetTop()->coco;
+	auto* window = coco->window;
+
+	[window setCollectionBehavior:NSWindowCollectionBehaviorTransient];
+	[window close];
+
+	delete coco;
 	DeleteTop();
+
 	popup = isopen = false;
 	int ii = FindIndex(mmtopctrl, this);
 	if(ii >= 0)


### PR DESCRIPTION
In this case the main fix is
```
[window setCollectionBehavior:NSWindowCollectionBehaviorTransient];
```
In this case when deleteing the window we are instrucing macos display server to hide this window in mission control. This is the simplest solution I found and looks like work in all cases that are present in TheIDE. I didn't notice any drawbacks.

https://developer.apple.com/documentation/appkit/nswindow/collectionbehavior-swift.struct/transient