### PR TITLE
CtrlCore: Cocoa always use bundled icon

### DIFF
--- a/uppsrc/CtrlCore/CocoCtrl.h
+++ b/uppsrc/CtrlCore/CocoCtrl.h
@@ -2,8 +2,10 @@ private:
 	friend struct MMCtrl;
 	friend struct MMImp;
 
-	static bool                local_dnd_copy;
-	static Ptr<Ctrl>           lastActive;
+	static bool      local_dnd_copy;
+	static Ptr<Ctrl> lastActive;
+	
+	static bool      always_use_bundled_icon;
 	
 	friend void CocoInit(int argc, const char **argv, const char **envptr);
 	
@@ -15,11 +17,14 @@ protected:
 	static void SyncAppIcon();
 	static void ResetCocoaMouse();
 	static void DoCancelPreedit();
-	static int  GetCaretBlinkTime()               { return 500; }
+	static int  GetCaretBlinkTime()       { return 500; }
 
 public:
-	static void      EndSession()              {}
-	static bool      IsEndSession()            { return false; }
+	static void EndSession()              {}
+	static bool IsEndSession()            { return false; }
+	
+	static void SetAlwaysUseBundledIcon(bool enable = true){ always_use_bundled_icon = enable; }
+	static bool IsAlwaysUseBundledIcon()                   { return always_use_bundled_icon; }
 	
 	void  *GetNSWindow() const;
 	void  *GetNSView() const;

--- a/uppsrc/CtrlCore/CocoCtrl.h
+++ b/uppsrc/CtrlCore/CocoCtrl.h
@@ -23,8 +23,8 @@ public:
 	static void EndSession()              {}
 	static bool IsEndSession()            { return false; }
 	
-	static void SetAlwaysUseBundledIcon(bool enable = true){ always_use_bundled_icon = enable; }
-	static bool IsAlwaysUseBundledIcon()                   { return always_use_bundled_icon; }
+	static void SetAlwaysUseBundledIcon(bool enable = true) { always_use_bundled_icon = enable; }
+	static bool IsAlwaysUseBundledIcon()                    { return always_use_bundled_icon; }
 	
 	void  *GetNSWindow() const;
 	void  *GetNSView() const;

--- a/uppsrc/CtrlCore/CocoTop.h
+++ b/uppsrc/CtrlCore/CocoTop.h
@@ -21,3 +21,5 @@ public:
 	Event<Bar&> WhenDockMenu;
 
 	void SetMainMenu(Event<Bar&> menu);
+	void SetBadgeLabel(const String& label = String());
+	

--- a/uppsrc/CtrlCore/CocoTop.mm
+++ b/uppsrc/CtrlCore/CocoTop.mm
@@ -31,7 +31,7 @@ void TopWindow::GuiPlatformConstruct()
 void TopWindow::SetBadgeLabel(const String& label)
 {
 	NSString* nlabel = [NSString stringWithUTF8String:~label];
-	[[[NSApplication sharedApplication] dockTile] setBadgeLabel:nlabel];
+	[[NSApp dockTile] setBadgeLabel:nlabel];
 }
 
 }

--- a/uppsrc/CtrlCore/CocoTop.mm
+++ b/uppsrc/CtrlCore/CocoTop.mm
@@ -2,7 +2,9 @@
 
 #ifdef GUI_COCOA
 
-NAMESPACE_UPP
+#include <CtrlCore/CocoMM.h>
+
+namespace Upp {
 
 #define LLOG(x)  // LOG(x)
 
@@ -25,7 +27,13 @@ bool TopWindow::IsTopMost() const
 void TopWindow::GuiPlatformConstruct()
 {
 }
-	
-END_UPP_NAMESPACE
+
+void TopWindow::SetBadgeLabel(const String& label)
+{
+	NSString* nlabel = [NSString stringWithUTF8String:~label];
+	[[[NSApplication sharedApplication] dockTile] setBadgeLabel:nlabel];
+}
+
+}
 
 #endif

--- a/uppsrc/CtrlCore/CocoWin.mm
+++ b/uppsrc/CtrlCore/CocoWin.mm
@@ -35,6 +35,8 @@ namespace Upp {
 
 static Vector<Ptr<Ctrl>> mmtopctrl; // should work without Ptr, but let us be defensive....
 
+bool Ctrl::always_use_bundled_icon = false;
+
 Ctrl *Ctrl::GetOwner()
 {
 	GuiLock __;
@@ -276,6 +278,9 @@ void TopWindow::SyncTitle()
 
 void Ctrl::SyncAppIcon()
 {
+	if(always_use_bundled_icon)
+		return;
+	
 	Ctrl *q = GetFocusCtrl();
 	if(!q)
 		q = lastActive;

--- a/uppsrc/CtrlCore/CtrlCore.upp
+++ b/uppsrc/CtrlCore/CtrlCore.upp
@@ -124,7 +124,7 @@ file
 	CocoClip.mm,
 	CocoCtrl.cpp,
 	CocoWnd.cpp,
-	CocoTop.cpp,
+	CocoTop.mm,
 	CocoChSysInit.cpp,
 	"RTF support" readonly separator,
 	ParseRTF.cpp,

--- a/uppsrc/ide/ide.cpp
+++ b/uppsrc/ide/ide.cpp
@@ -570,6 +570,12 @@ void Ide::SetIdeState(int newstate)
 }
 
 void Ide::MakeIcon() {
+#ifdef PLATFORM_COCOA
+	String badge = IsOpen() ? main : "";
+	SetBadgeLabel(badge);
+	return;
+#endif
+	
 	Image li = IdeImg::Icon256();
 #ifndef PLATFORM_POSIX // Kubuntu is using this icon for window while ignoring it in taskbar...
 	WString mp = main.ToWString();

--- a/uppsrc/ide/main.cpp
+++ b/uppsrc/ide/main.cpp
@@ -217,6 +217,9 @@ void AppMain___()
 	Ctrl::SetDarkThemeEnabled();
 	Ctrl::SkinChangeSensitive();
 	Ctrl::SetAppName("TheIDE");
+#ifdef PLATFORM_COCOA
+	Ctrl::SetAlwaysUseBundledIcon();
+#endif
 
 	SetLanguage(LNG_ENGLISH);
 	SetDefaultCharset(CHARSET_UTF8);


### PR DESCRIPTION
This PR introduces SetAlwaysUseBundledIcon method for Cocoa. It supposed to globaly disable SyncAppIcon operation. Thanks to that the app that uses this function is more consistent with the macos feeling. Here is the samples:

1. Before
<img width="528" height="83" alt="Zrzut ekranu 2026-01-3 o 02 05 05" src="https://github.com/user-attachments/assets/016776d4-36fb-4ab4-b8c7-3b4439184db7" />
<img width="528" height="83" alt="Zrzut ekranu 2026-01-3 o 02 06 31" src="https://github.com/user-attachments/assets/e229bfab-3c7e-40af-8217-1f2999a67661" />

2. After
<img width="528" height="83" alt="Zrzut ekranu 2026-01-3 o 02 07 37" src="https://github.com/user-attachments/assets/5ad97ec6-3dfa-4abf-83e7-df05a4e7574f" />
<img width="528" height="83" alt="Zrzut ekranu 2026-01-3 o 02 08 05" src="https://github.com/user-attachments/assets/1dbc5c4b-2b1f-4e05-ac88-75a5403002ab" />

For 'After' the app icon in the dock during the runtime scales to the os settings. Without this option it does not.

Please feel free to rename the funcionality to whatever you want. I just tried to use your notation, but maybe we can name it better.