### PR TITLE
Core: Fix LaunchWebBrowser on macOS to handle addresses with dolar sign.

### DIFF
--- a/uppsrc/Core/App.cpp
+++ b/uppsrc/Core/App.cpp
@@ -654,7 +654,9 @@ void LaunchWebBrowser(const String& url)
 void    LaunchWebBrowser(const String& url)
 {
 #ifdef PLATFORM_MACOS
-	IGNORE_RESULT(system("open " + url));
+	String u = url;
+	u.Replace("$", "\\$");
+	IGNORE_RESULT(system("open " + u));
 #else
 	const char * browser[] = {
 		"htmlview", "xdg-open", "x-www-browser", "firefox", "konqueror", "opera", "epiphany", "galeon", "netscape"


### PR DESCRIPTION
In TheIDE handling for these links doesn't work as expected:
```
menu.AddMenu("Online documentation..", IdeImg::Go_forward(), callback1(LaunchWebBrowser, "http://www.ultimatepp.org/www$uppweb$documentation$en-us.html"));
menu.AddMenu("Common information..", IdeImg::Go_forward(), callback1(LaunchWebBrowser, "http://www.ultimatepp.org/www$uppweb$community$en-us.html"));
```
The solution is to escape $ dolar signs.