### PR TITLE
CtrlCore: Improve minimizebox and maximizebox handling on macos.

### DIFF
--- a/uppsrc/CtrlCore/CocoWin.mm
+++ b/uppsrc/CtrlCore/CocoWin.mm
@@ -290,9 +290,15 @@ void TopWindow::SyncCaption()
 	GuiLock __;
 	if(top) {
 		SyncTitle();
-		NSWindow *window = GetTop()->coco->window;
-		[[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:!minimizebox];
-		[[window standardWindowButton:NSWindowZoomButton] setHidden:!maximizebox];
+		NSWindow* window = GetTop()->coco->window;
+
+		NSWindowStyleMask mask = [window styleMask];
+		mask = minimizebox ? (mask | NSWindowStyleMaskMiniaturizable)
+		                   : (mask & ~NSWindowStyleMaskMiniaturizable);
+		mask = maximizebox ? (mask | NSWindowStyleMaskResizable)
+		                   : (mask & ~NSWindowStyleMaskResizable);
+
+		[window setStyleMask:mask];
 	}
 	SyncAppIcon();
 }


### PR DESCRIPTION
We are handling sync caption not optimally on macos. To handle it correctly we need to stop using hide and instead of this use more bulletproff styleMas.

Here is the examples.

Before
<img width="284" height="165" alt="Zrzut ekranu 2026-01-7 o 21 23 00" src="https://github.com/user-attachments/assets/f592ea75-9fb7-4a02-9d21-3296cc3db4ca" />

After
<img width="296" height="166" alt="Zrzut ekranu 2026-01-7 o 21 22 29" src="https://github.com/user-attachments/assets/d02300c4-2ece-42eb-b37a-ff91ba8c6d8f" />

Also, the new version is more consistent with how other system apps are handling (Terminal settings - minimize and maximize disabled):
<img width="522" height="135" alt="Zrzut ekranu 2026-01-7 o 21 27 13" src="https://github.com/user-attachments/assets/27056ddc-1dc9-410c-af8f-1ae8a52b8eed" />

<img width="406" height="137" alt="Zrzut ekranu 2026-01-7 o 21 41 46" src="https://github.com/user-attachments/assets/ea9a0598-2b0d-4ec9-9607-e830e25a328b" />


On above image these three buttons are always visible, but two of them are disable.

I find another example of our dialog (Print).

Before
<img width="529" height="364" alt="Zrzut ekranu 2026-01-7 o 21 36 00" src="https://github.com/user-attachments/assets/45582672-768c-41f6-96ef-a4fb02948370" />

After (more consistent with other apps, however the initial variant might look better)
<img width="534" height="378" alt="Zrzut ekranu 2026-01-7 o 21 37 46" src="https://github.com/user-attachments/assets/9e6b50b1-5fc7-4e2b-9695-816f0fec2aff" />

Docs https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct?language=objc