### PR TITLE
Added support for Visual Studio 2026

### DIFF
--- a/uppsrc/ide/Builders/MscBuilder.cpp
+++ b/uppsrc/ide/Builders/MscBuilder.cpp
@@ -125,7 +125,7 @@ bool MscBuilder::IsMsc86() const
 {
 	return HasFlag("MSC8") || HasFlag("MSC9") || HasFlag("MSC10") || HasFlag("MSC11")
 		|| HasFlag("MSC12") || HasFlag("MSC15") || HasFlag("MSC14") || HasFlag("MSC17")
-		|| HasFlag("MSC19") || HasFlag("MSC22");
+		|| HasFlag("MSC19") || HasFlag("MSC22") || HasFlag("MSC26");
 }
 
 bool MscBuilder::IsMscArm() const
@@ -137,7 +137,7 @@ bool MscBuilder::IsMsc64() const
 {
 	return HasFlag("MSC8X64") || HasFlag("MSC9X64") || HasFlag("MSC10X64") || HasFlag("MSC11X64")
 		|| HasFlag("MSC12X64") || HasFlag("MSC14X64") || HasFlag("MSC15X64") || HasFlag("MSC17X64")
-		|| HasFlag("MSC19X64") || HasFlag("MSC22X64");
+		|| HasFlag("MSC19X64") || HasFlag("MSC22X64") || HasFlag("MSC26X64");
 }
 
 String MscBuilder::LinkerName() const
@@ -630,6 +630,7 @@ bool MscBuilder::Link(const Vector<String>& linkfile, const String& linkoptions,
 		|| HasFlag("MSC17") || HasFlag("MSC17X64")
 		|| HasFlag("MSC19") || HasFlag("MSC19X64")
 		|| HasFlag("MSC22") || HasFlag("MSC22X64")
+		|| HasFlag("MSC26") || HasFlag("MSC26X64")
 	;
 	for(int i = 0; i < linkfile.GetCount(); i++)
 		if(GetFileTime(linkfile[i]) > targettime) {
@@ -764,6 +765,8 @@ INITIALIZER(MscBuilder)
 	RegisterBuilder("MSC19X64", CreateMscBuilder);
 	RegisterBuilder("MSC22", CreateMscBuilder);
 	RegisterBuilder("MSC22X64", CreateMscBuilder);
+	RegisterBuilder("MSC26", CreateMscBuilder);
+	RegisterBuilder("MSC26X64", CreateMscBuilder);
 	RegisterBuilder("EVC_ARM", CreateMscBuilder);
 	RegisterBuilder("EVC_MIPS", CreateMscBuilder);
 	RegisterBuilder("EVC_SH3", CreateMscBuilder);

--- a/uppsrc/ide/InstantSetup.cpp
+++ b/uppsrc/ide/InstantSetup.cpp
@@ -286,8 +286,8 @@ void InstantSetup()
 				kit81 = df.Get("/windows kits/8.1", "include");
 			
 			LOG("=============");
-			RLOG(method);
-			RLOG(vc);
+			DUMP(method);
+			DUMP(vc);
 			DUMP(bin);
 			DUMP(inc);
 			DUMP(kit81);

--- a/uppsrc/ide/InstantSetup.cpp
+++ b/uppsrc/ide/InstantSetup.cpp
@@ -212,15 +212,22 @@ void InstantSetup()
 				default_method = Nvl(default_method, method);
 		}
 
-	enum { VS_2015, VS_2017, BT_2017, VS_2019, VSP_2019, BT_2019, VS_2022, VSP_2022, BT_2022 };
+	enum {
+		VS_2015,
+		VS_2017, BT_2017,
+		VS_2019, VSP_2019, BT_2019,
+		VS_2022, VSP_2022, BT_2022,
+		VS_2026, BT_2026
+	};
 	DirFinder df;
 
-	for(int version = VS_2019; version <= BT_2022; version++)
+	for(int version = VS_2019; version <= BT_2026; version++)
 		for(int x64 = 0; x64 < 2; x64++) {
 			String x86method = decode(version, VS_2015, "MSVS15",
 			                                   VS_2017, "MSVS17", BT_2017, "MSBT17",
 			                                   VS_2019, "MSVS19", VSP_2019, "MSVSP19", BT_2019, "MSBT19",
 			                                   VS_2022, "MSVS22", VSP_2022, "MSVSP22", BT_2022, "MSBT22",
+			                                   VS_2026, "MSVS26", BT_2026, "MSBT26",
 			                                   "MSBT");
 			String x64s = x64 ? "x64" : "";
 			String method = x86method + x64s;
@@ -228,7 +235,8 @@ void InstantSetup()
 			                                 VS_2017, "MSC17", BT_2017, "MSC17",
 			                                 VS_2019, "MSC19", VSP_2019, "MSC19", BT_2019, "MSC19",
 			                                 VS_2022, "MSC22", VSP_2022, "MSC22", BT_2022, "MSC22",
-			                                 "MSC22"
+			                                 VS_2026, "MSC26", BT_2026, "MSC26",
+			                                 "MSC26"
 			                 ) + ToUpper(x64s);
 		
 		#ifdef INSTANT_TESTING
@@ -261,6 +269,8 @@ void InstantSetup()
 				                            BT_2022, "/microsoft visual studio/2022/buildtools/vc/tools/msvc",
 				                            VS_2022, "/microsoft visual studio/2022/community/vc/tools/msvc",
 				                            VSP_2022, "/microsoft visual studio/2022/professional/vc/tools/msvc",
+				                            BT_2026, "/microsoft visual studio/18/buildtools/vc/tools/msvc",
+				                            VS_2026, "/microsoft visual studio/18/community/vc/tools/msvc",
 				                            ""),
 				            x64 ? "bin/hostx64/x64/cl.exe;bin/hostx64/x64/mspdb140.dll"
 				                : "bin/hostx86/x86/cl.exe;bin/hostx86/x86/mspdb140.dll");
@@ -275,8 +285,8 @@ void InstantSetup()
 				kit81 = df.Get("/windows kits/8.1", "include");
 			
 			LOG("=============");
-			DUMP(method);
-			DUMP(vc);
+			RLOG(method);
+			RLOG(vc);
 			DUMP(bin);
 			DUMP(inc);
 			DUMP(kit81);

--- a/uppsrc/ide/InstantSetup.cpp
+++ b/uppsrc/ide/InstantSetup.cpp
@@ -217,7 +217,7 @@ void InstantSetup()
 		VS_2017, BT_2017,
 		VS_2019, VSP_2019, BT_2019,
 		VS_2022, VSP_2022, BT_2022,
-		VS_2026, BT_2026
+		VS_2026, VSP_2026, BT_2026
 	};
 	DirFinder df;
 
@@ -227,7 +227,7 @@ void InstantSetup()
 			                                   VS_2017, "MSVS17", BT_2017, "MSBT17",
 			                                   VS_2019, "MSVS19", VSP_2019, "MSVSP19", BT_2019, "MSBT19",
 			                                   VS_2022, "MSVS22", VSP_2022, "MSVSP22", BT_2022, "MSBT22",
-			                                   VS_2026, "MSVS26", BT_2026, "MSBT26",
+			                                   VS_2026, "MSVS26", VSP_2026, "MSVSP26", BT_2026, "MSBT26",
 			                                   "MSBT");
 			String x64s = x64 ? "x64" : "";
 			String method = x86method + x64s;
@@ -235,7 +235,7 @@ void InstantSetup()
 			                                 VS_2017, "MSC17", BT_2017, "MSC17",
 			                                 VS_2019, "MSC19", VSP_2019, "MSC19", BT_2019, "MSC19",
 			                                 VS_2022, "MSC22", VSP_2022, "MSC22", BT_2022, "MSC22",
-			                                 VS_2026, "MSC26", BT_2026, "MSC26",
+			                                 VS_2026, "MSC26", VSP_2026, "MSC26", BT_2026, "MSC26",
 			                                 "MSC26"
 			                 ) + ToUpper(x64s);
 		
@@ -271,6 +271,7 @@ void InstantSetup()
 				                            VSP_2022, "/microsoft visual studio/2022/professional/vc/tools/msvc",
 				                            BT_2026, "/microsoft visual studio/18/buildtools/vc/tools/msvc",
 				                            VS_2026, "/microsoft visual studio/18/community/vc/tools/msvc",
+				                            VSP_2026, "/microsoft visual studio/18/professional/vc/tools/msvc",
 				                            ""),
 				            x64 ? "bin/hostx64/x64/cl.exe;bin/hostx64/x64/mspdb140.dll"
 				                : "bin/hostx86/x86/cl.exe;bin/hostx86/x86/mspdb140.dll");


### PR DESCRIPTION
Just adding support for the next release of Visual Studio - 2026. There is one change, instead of year in the path, there is an ordinary version number. So, instead of having 2026 it is 18.