### PR TITLE
RichEdit: Fix to compile with x86 MSVC compiler.

### DIFF
--- a/uppsrc/RichEdit/DiagramBar.cpp
+++ b/uppsrc/RichEdit/DiagramBar.cpp
@@ -103,7 +103,7 @@ void DiagramEditor::TheBar(Bar& bar)
 		}
 		else {
 			m.pos = Pointf(Point(isz)) / 2;
-			m.size = m.pos - 2;
+			m.size = m.pos - 2.0;
 		}
 		m.width = log(m.width + 1);
 		bar.Add(MakeIcon(m, isz), [=] {

--- a/uppsrc/RichEdit/DiagramIcon.cpp
+++ b/uppsrc/RichEdit/DiagramIcon.cpp
@@ -41,7 +41,7 @@ Image DiagramEditor::ShapeIcon(int i)
 	}
 	else {
 		m.pos = Pointf(Point(isz)) / 2;
-		m.size = m.pos - 2;
+		m.size = m.pos - 2.0;
 	}
 	m.width = DPI(1);
 	m.paper = Null;


### PR DESCRIPTION
It looks like 32 bit version of RichEdit code is no longer compatible with x86 MSVC compiler. This PR address this issue.

The errors are:
```
C:\Prototable\upp\git\uppsrc\RichEdit\DiagramIcon.cpp (44): error C2666: ,Upp::Point_<double>::operator -": overloaded functions have similar conversions
C:\Prototable\upp\git\uppsrc\RichEdit\DiagramBar.cpp (106): error C2666: ,Upp::Point_<double>::operator -": overloaded functions have similar conversions
```

