### PR TITLE
CtrlCore: Implemented drop operation for files in Cocoa.

### DIFF
--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -124,8 +124,6 @@ void AppendClipboard(bool dnd, const char *format, const Value& value, String (*
 {
 	GuiLock __;
 
-	RLOG(String("AppendClipboard: format: ") + format + " value: " + String(value));
-
 	auto& data = ClipboardOwner(dnd)->data;
 
 	for(String fmt : Split(format, ';'))

--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -43,6 +43,7 @@ NSPasteboard *Pasteboard(bool dnd = false)
 	};
 	
 	NSPasteboard *pasteboard = Upp::Pasteboard(dnd);
+	[pasteboard clearContents];
 
 	if([type isEqualTo:NSPasteboardTypeString]) {
 		Upp::String raw = render("text");
@@ -50,6 +51,21 @@ NSPasteboard *Pasteboard(bool dnd = false)
 			raw = source->GetDropData("text");
 	    [pasteboard setString:[NSString stringWithUTF8String:raw]
 	                forType:type];
+		return;
+	}
+	else if([type isEqualTo:NSPasteboardTypeFileURL]) {
+		Upp::String raw = render("files");
+		Upp::Value v = ParseJSON(raw);
+		if(!IsValueArray(v))
+			return;
+		Upp::ValueArray va = v;
+
+		NSMutableArray* array = [NSMutableArray array];
+		for(int i = 0; i < va.GetCount(); ++i) {
+			NSString *path = [NSString stringWithUTF8String:~va[i]];
+			[array addObject:[NSURL fileURLWithPath:path]];
+		}
+		[pasteboard writeObjects:array];
 		return;
 	}
 	
@@ -107,6 +123,8 @@ NSMutableSet *PasteboardTypes(const Vector<String>& fmt)
 void AppendClipboard(bool dnd, const char *format, const Value& value, String (*render)(const Value& data))
 {
 	GuiLock __;
+
+	RLOG(String("AppendClipboard: format: ") + format + " value: " + String(value));
 
 	auto& data = ClipboardOwner(dnd)->data;
 
@@ -386,21 +404,12 @@ Vector<String> GetFiles(PasteClip& clip)
 }
 
 void AppendFiles(VectorMap<String, ClipData>& clip, const Vector<String>& files)
-{ // TODO (does not work in modern MacOS)
-#if 0
-	if(files.GetCount() == 0)
-		return;
-	String xml =
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
-        "<plist version=\"1.0\"><array>\n"
-    ;
-	for(String f : files)
-		xml << XmlTag("string").Text(f);
-	xml << "</array></plist>";
-	DDUMP(xml);
-	clip.GetAdd("files") = xml;
-#endif
+{
+	JsonArray array;
+	for(auto f : files) {
+		array << f;
+	}
+	clip.GetAdd("files") = ~array;
 }
 
 Ctrl * Ctrl::GetDragAndDropSource()


### PR DESCRIPTION
This should fix https://github.com/ultimatepp/ultimatepp/issues/298. DropFiles example works like a charm after this changes. You can drop from and to Finder without any problems.