### PR TITLE
CtrlCore: drag and drop in line edit like ctrls now works as expected on macOS.

### DIFF
--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -441,8 +441,6 @@ int Ctrl::DoDragAndDrop(const char *fmts, const Image& sample, dword actions,
 	ASSERT_(sCurrentMouseEvent__, "Drag can only start within LeftDrag!");
 	if(!sCurrentMouseEvent__)
 		return DND_NONE;
-	if(data.GetCount() == 0)
-		return DND_NONE; // Cocoa crashes if there is nothing to drop
 	NSWindow *nswindow = (NSWindow *)GetTopCtrl()->GetNSWindow();
 	ASSERT_(nswindow, "Ctrl is not in open window");
 	if(!nswindow)


### PR DESCRIPTION
It looks like the drag and drop for functions that call DoDragAndDrop without providing data parameter doesn't work as expected. However, there are plenty places where it is called like that. For example CodeEditor is using it to move one block of code to another place. So, it should work...

I fix it simply. It looks like the following if was misleading:
```
	if(data.GetCount() == 0)
		return DND_NONE; // Cocoa crashes if there is nothing to drop
```
After removing this line everything starts to work as expected. Without any crashes.