### PR TITLE
Ide: Toolbar in the row is now true on macOS

### DIFF
--- a/uppsrc/ide/ide.h
+++ b/uppsrc/ide/ide.h
@@ -628,7 +628,12 @@ public:
 	byte      default_charset;
 	bool      indent_spaces;
 	bool      show_status_bar;
-	bool      toolbar_in_row;
+	bool      toolbar_in_row =
+#ifdef PLATFORM_MACOS
+		true;
+#else
+		false;
+#endif
 	bool      disable_custom_caption = false;
 	bool      show_tabs;
 	bool      show_spaces;
@@ -674,11 +679,10 @@ public:
 	bool      macos_update_icon = false;
 	bool      search_downloads =
 #ifdef PLATFORM_MACOS
-		false
+		false;
 #else
-		true
+		true;
 #endif
-	;
 		
 
 	// Formats editor's code with Ide format parameters

--- a/uppsrc/ide/idewin.cpp
+++ b/uppsrc/ide/idewin.cpp
@@ -529,7 +529,6 @@ Ide::Ide()
 	menubar.AreaLook(1);
 	toolbar.WhenHelp = ~statusbar;
 	toolbar.AreaLook(1);
-	toolbar_in_row = false;
 	WhenClose = THISBACK(Exit);
 
 	editor_p.Add(editor.SizePos());


### PR DESCRIPTION
Since there is no menubar on macOS and we are alwasy using system wide menu bar. The default behaviour with no toolbar in the row looks strange. So, this PR changes this option. We can also, consider to hide this option from settings...

Toolbar in the row
<img width="1985" height="200" alt="Zrzut ekranu 2026-01-19 o 00 07 44" src="https://github.com/user-attachments/assets/dd025a05-4b67-4430-a62f-d61ad2f35473" />

No toolbar in the row, too much empty space...
<img width="1985" height="200" alt="Zrzut ekranu 2026-01-19 o 00 07 58" src="https://github.com/user-attachments/assets/1435f75b-1c1d-4a4f-9d94-3c1e940b26ab" />

BTW, We can consider moving the question mark when Toolbar in the Row is active after the current line display indicator.
