### PR TITLE
Sqlite3: fix to compile on macOS.

### DIFF
--- a/uppsrc/plugin/sqlite3/sqlite3.upp
+++ b/uppsrc/plugin/sqlite3/sqlite3.upp
@@ -13,6 +13,8 @@ options
 
 options(SQLITE_HAS_CODEC) -DSQLITE_HAS_CODEC;
 
+link(OSX) "-framework Security";
+
 file
 	Sqlite3.h,
 	Sqlite3Schema.h,


### PR DESCRIPTION
It looks like there is a compilation error when compiling anything that uses plugin/Sqlite3 on macOS. The error is:
```
Linking...
Undefined symbols for architecture arm64:
  "_SecRandomCopyBytes", referenced from:
      _entropy in lib.c.o
  "_kSecRandomDefault", referenced from:
      _entropy in lib.c.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

The fix is easy, you need to use `-framework Security` link option.