### PR TITLE
GridCtrl: fix warnings on macOS.

### DIFF
--- a/uppsrc/GridCtrl/GridDisplay.cpp
+++ b/uppsrc/GridCtrl/GridDisplay.cpp
@@ -287,13 +287,11 @@ int GridDisplay::GetLinesCount(int cx, const wchar* s, const Font& font, bool wr
 		
 	const wchar * e = t;
 	int ccx = max(5, cx);
-	int enters = 0;
 	int lines = 0;
 
 	while(*p)
 	{
 		bool nextline = *p == '\n';
-		enters += int(nextline);
 
 		if(nextline || *(p + 1) == '\0')
 		{
@@ -304,7 +302,7 @@ int GridDisplay::GetLinesCount(int cx, const wchar* s, const Font& font, bool wr
 				{
 					lines += tcx / ccx;
 					if(tcx % ccx > 0)
-						lines++;						
+						lines++;
 				}
 				else
 					lines++;

--- a/uppsrc/GridCtrl/GridUtils.cpp
+++ b/uppsrc/GridCtrl/GridUtils.cpp
@@ -6,23 +6,24 @@ LineEdit *dlog = NULL;
 int dlev = 0;
 
 static int pos = 0;
+static constexpr int buff_size = 1024;
 
 void LogCon(const char *fmt, ...)
 {
-	char buffer[1024];
+	char buffer[buff_size];
 	va_list argptr;
 	va_start(argptr, fmt);
-	vsprintf(buffer, fmt, argptr);
+	vsnprintf(buffer, buff_size, fmt, argptr);
 	va_end(argptr);
 	LOG(buffer);
 }
 
 void LogCon(int level, const char *fmt, ...)
 {
-	char buffer[1024];
+	char buffer[buff_size];
 	va_list argptr;
 	va_start(argptr, fmt);
-	vsprintf(buffer, fmt, argptr);
+	vsnprintf(buffer, buff_size, fmt, argptr);
 	va_end(argptr);
 	LOG(buffer);
 }
@@ -33,10 +34,10 @@ void LogGui(const char *fmt, ...)
 		return;
 
 	pos = dlog->GetLength();
-	char buffer[1024];
+	char buffer[buff_size];
 	va_list argptr;
 	va_start(argptr, fmt);
-	int l = vsprintf(buffer, fmt, argptr);
+	int l = vsnprintf(buffer, buff_size, fmt, argptr);
 	va_end(argptr);
 
 	dlog->Insert(pos, buffer);
@@ -52,10 +53,10 @@ void LogGui(int level, const char *fmt, ...)
 		return;
 
 	pos = dlog->GetLength();
-	char buffer[1024];
+	char buffer[buff_size];
 	va_list argptr;
 	va_start(argptr, fmt);
-	int l = vsprintf(buffer, fmt, argptr);
+	int l = vsnprintf(buffer, buff_size, fmt, argptr);
 	va_end(argptr);
 
 	dlog->Insert(pos, buffer);


### PR DESCRIPTION
Fixing following warnings:
- Remove unused enteres variable in GridDisplay.cpp
- Replaced vsprintf with secure vsnprintf in GridUtils.cpp