### PR TITLE
CtrlCore: Fix macOS Ide crash when closing app from dock.

### DIFF
--- a/uppsrc/CtrlCore/CocoApp.mm
+++ b/uppsrc/CtrlCore/CocoApp.mm
@@ -45,6 +45,11 @@ NSMenu *Cocoa_DockMenu();
 	Upp::Ctrl::PostReSkin();
 }
 
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
+	Upp::GuiLock __;
+	Upp::TopWindow::ShutdownWindows();
+	return NSTerminateCancel;
+}
 
 @end
 

--- a/uppsrc/CtrlCore/TopWindow.cpp
+++ b/uppsrc/CtrlCore/TopWindow.cpp
@@ -500,14 +500,18 @@ void TopWindow::ShutdownWindows()
 		again = false;
 		for(int i = 0; i < tc.GetCount(); i++) {
 			Ptr<TopWindow> w = dynamic_cast<TopWindow *>(tc[i]);
-			if(w && w->IsOpen() && w->IsEnabled()) {
+			if(w && w->IsOpen()) {
 				again = true;
 				w->SetForeground();
 				w->ShutdownWindow();
-				if(w && w->IsOpen())
+				if(w && w->IsOpen()) {
 					w->WhenClose();
-				if(!w || !w->IsOpen())
+					if(w)
+						w->Close();
+				}
+				if(!w || !w->IsOpen()) {
 					break;
+				}
 			}
 		}
 	}

--- a/uppsrc/CtrlCore/TopWindow.cpp
+++ b/uppsrc/CtrlCore/TopWindow.cpp
@@ -509,9 +509,8 @@ void TopWindow::ShutdownWindows()
 					if(w)
 						w->Close();
 				}
-				if(!w || !w->IsOpen()) {
+				if(!w || !w->IsOpen())
 					break;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
TheIDE currently crashes 80-90% of the time when closed via the dock while a main package is open. This instability stems from an unclean exit sequence, leading to undefined behavior during shutdown. To resolve this, we must intercept the system's terminate event and manage the lifecycle explicitly. Implementing a call to TopWindow::ShutdownWindows() within the close event handler ensures all resources are released properly and prevents the crash.

Regarding the following conditional logic:
```
if(w && w->IsOpen() && w->IsEnabled()) {
```
Removing the IsEnabled() check is necessary to support scenarios with nested windows. For instance, if the 'Settings' dialog is open in TheIDE, the main application window is technically disabled. Retaining the IsEnabled() check would prevent the shutdown sequence from reaching the underlying windows, resulting in only the top-level active dialog being closed rather than the entire application. Not sure how it will be handled on other platforms...

Here is the close option that is causing problems...
<img width="196" height="259" alt="Zrzut ekranu 2026-01-23 o 16 59 06" src="https://github.com/user-attachments/assets/7d076523-9dcb-4716-badc-3469a267241f" />

I tested this solution on TheIDE and UWord (delete this in WhenClose logic!).
