### PR TITLE
CtrlCore: remove titlebar from splash on Wayland.

### DIFF
--- a/uppsrc/CtrlCore/GtkCreate.cpp
+++ b/uppsrc/CtrlCore/GtkCreate.cpp
@@ -70,12 +70,8 @@ void Ctrl::Create(Ctrl *owner, bool popup)
 	w.gdk = nullptr;
 	
 	TopWindow *tw = dynamic_cast<TopWindow *>(this);
-	if(popup) {
+	if(popup)
 		gtk_window_set_decorated(gtk(), FALSE);
-		if(IsWayland() && !owner) {
-			gtk_window_set_titlebar(gtk(), gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
-		}
-	}
 	gtk_window_set_type_hint(gtk(),
 	            popup ? /*owner ? GDK_WINDOW_TYPE_HINT_COMBO : */GDK_WINDOW_TYPE_HINT_POPUP_MENU
 	                  : tw && tw->tool ? GDK_WINDOW_TYPE_HINT_UTILITY
@@ -122,6 +118,8 @@ void Ctrl::Create(Ctrl *owner, bool popup)
 		ONCELOCK {
 			UpdateWindowFrameMargins();
 		}
+		if(IsWayland() && !owner)
+			gtk_window_set_titlebar(gtk(), gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
 		top->client = top->window;
 	}
 

--- a/uppsrc/CtrlCore/GtkCreate.cpp
+++ b/uppsrc/CtrlCore/GtkCreate.cpp
@@ -70,8 +70,12 @@ void Ctrl::Create(Ctrl *owner, bool popup)
 	w.gdk = nullptr;
 	
 	TopWindow *tw = dynamic_cast<TopWindow *>(this);
-	if(popup)
+	if(popup) {
 		gtk_window_set_decorated(gtk(), FALSE);
+		if(IsWayland() && !owner) {
+			gtk_window_set_titlebar(gtk(), gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0));
+		}
+	}
 	gtk_window_set_type_hint(gtk(),
 	            popup ? /*owner ? GDK_WINDOW_TYPE_HINT_COMBO : */GDK_WINDOW_TYPE_HINT_POPUP_MENU
 	                  : tw && tw->tool ? GDK_WINDOW_TYPE_HINT_UTILITY


### PR DESCRIPTION
This seems to fix the problem with decorated splash screen on Wayland. I didn't notice any drawbacks. The below code works fine with X11, but on X11 it works as expect and it is not needed. So, I just added check if wayland to execute it.