### PR TITLE
CtrlCore: fix release caption for tab bar on macOS.

### DIFF
--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -499,6 +499,7 @@ int Ctrl::DoDragAndDrop(const char *fmts, const Image& sample, dword actions,
 	
 	local_dnd_copy = false; // macos does not have ability to change action in performDragOperation
 
+	RLOG("DragImage");
 	[nswindow dragImage:nsimg
 	                 at:p
 	             offset:NSMakeSize(0, 0)
@@ -510,8 +511,8 @@ int Ctrl::DoDragAndDrop(const char *fmts, const Image& sample, dword actions,
 	ClipboardOwner(true)->source = NULL;
 
 	[pool release];
-
     CGImageRelease(cgimg);
+    ReleaseCapture();
     
     if(local_dnd_copy) // action was local and changed to copy in DragAndDrop
         return DND_COPY;

--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -499,7 +499,6 @@ int Ctrl::DoDragAndDrop(const char *fmts, const Image& sample, dword actions,
 	
 	local_dnd_copy = false; // macos does not have ability to change action in performDragOperation
 
-	RLOG("DragImage");
 	[nswindow dragImage:nsimg
 	                 at:p
 	             offset:NSMakeSize(0, 0)


### PR DESCRIPTION
Seems ReleaseCapture() in Ctrl::DoDragAndDrop for Cocoa is needed to avoid problems with TabBar on macOS. I didn't notice any regressions in other places. Maybe not the cleanest solution, but for now should be fine.

Please keep in mind that the logic in Ctrl::DoDragAndDrop is being continue when user stop drag after executing following code:
```
[nswindow dragImage:nsimg
	                 at:p
	             offset:NSMakeSize(0, 0)
	              event:sCurrentMouseEvent__
	         pasteboard:Pasteboard(true)
	             source:src
	          slideBack:YES];
```

Please keep in mind that we will need to rewrite this code to the newer beginDraggingSessionWithItems. dragImage was depricated in latest macOS 26.2. Still compiler doesn't generate warnings, but it will change of the future. So, treat the current code as temporary solution.