### PR TITLE
CtrlCore: Fix GTK file drop to Dolphin and Firefox on Wayland

### DIFF
--- a/uppsrc/CtrlCore/GtkClip.cpp
+++ b/uppsrc/CtrlCore/GtkClip.cpp
@@ -385,7 +385,7 @@ void AppendFiles(VectorMap<String, ClipData>& data, const Vector<String>& files)
 		return;
 	String h;
 	for(const String& f : files) {
-		h << "file://" << UrlEncode(f) << '\n';
+		h << "file://" << UrlEncode(f) << "\r\n";
 		h.Replace("%2F", "/");
 	}
 	data.GetAdd("files") = h;

--- a/uppsrc/CtrlCore/GtkClip.cpp
+++ b/uppsrc/CtrlCore/GtkClip.cpp
@@ -385,7 +385,7 @@ void AppendFiles(VectorMap<String, ClipData>& data, const Vector<String>& files)
 		return;
 	String h;
 	for(const String& f : files) {
-		h << "file://" << UrlEncode(f) << "\r\n";
+		h << "file://" << UrlEncode(f) << "\n";
 		h.Replace("%2F", "/");
 	}
 	data.GetAdd("files") = h;

--- a/uppsrc/CtrlCore/GtkClip.cpp
+++ b/uppsrc/CtrlCore/GtkClip.cpp
@@ -384,8 +384,10 @@ void AppendFiles(VectorMap<String, ClipData>& data, const Vector<String>& files)
 	if(files.GetCount() == 0)
 		return;
 	String h;
-	for(String f : files)
+	for(const String& f : files) {
 		h << "file://" << UrlEncode(f) << '\n';
+		h.Replace("%2F", "/");
+	}
 	data.GetAdd("files") = h;
 }
 

--- a/uppsrc/CtrlCore/GtkClip.cpp
+++ b/uppsrc/CtrlCore/GtkClip.cpp
@@ -385,7 +385,7 @@ void AppendFiles(VectorMap<String, ClipData>& data, const Vector<String>& files)
 		return;
 	String h;
 	for(const String& f : files) {
-		h << "file://" << UrlEncode(f) << "\n";
+		h << "file://" << UrlEncode(f) << '\n';
 		h.Replace("%2F", "/");
 	}
 	data.GetAdd("files") = h;


### PR DESCRIPTION
It looks like we need to recover slashes after doing UrlEncode. So, instead of having following path:
```
file://%2Fhome%2Fklugier%2Fupp%2Ffr-fr.udc
```
It should be
```
file:///home/klugier/upp/fr-fr.udc
```
After changing the logic drop to Dolphin and Firefox on Wayland works as expected.

I tested also on pure X11 and it works as expected.