### PR TITLE
Fix shebang line in install script

### DIFF
--- a/uppbox/MakePosixInstall/scripts.cpp
+++ b/uppbox/MakePosixInstall/scripts.cpp
@@ -1,5 +1,5 @@
 const char *install_script =
-R"--(##!/usr/bin/env bash
+R"--(#!/usr/bin/env bash
 
 AskContinue()
 {


### PR DESCRIPTION
The install script doesn't work on Ubuntu 25.04. It generates following error:
```
./install: 75: bad substituion
```
The reason of that error is that we incorrect sheban in our script that can not force the script execution under bash:
```
##!/usr/bin/env bash
```
It should be:
```
#!/usr/bin/env bash
```

If we won't release soon this should be in hotfix release for 2025.1.