### PR TITLE
Fix issue with erasing UppOut from TheIDE

### DIFF
--- a/uppsrc/ide/Build.cpp
+++ b/uppsrc/ide/Build.cpp
@@ -121,7 +121,12 @@ void Ide::PackageClean()
 
 void Ide::CleanUppOut()
 {
-	String out = GetOutputDir();
+	String out = GetUppOut();
+	if(out.IsEmpty()) {
+		ErrorOK("The output directory has not been defined.");
+		return;
+	}
+
 	if(!PromptYesNo(Format("Erase the whole output directory [* \1%s\1]?", out)))
 		return;
 	console.Clear();


### PR DESCRIPTION
The current implementation of Ide::CleanUppOut is broken. It removes the application's direct build directory, which requires the target to have been built at least once. Otherwise the clean operation fails. It also doesn’t remove the actual upp.out user data we want to clean (for example, ~/.config/upp.out). So, the current implementation just performs a partial cleaning.

I added an extra check to prevent accidentally passing an empty directory path, which could cause serious harm to the user. Although the new implementation makes that scenario very unlikely since we are not relay on target variable that is set during the build process.

Original issue https://www.ultimatepp.org/forums/index.php?t=msg&goto=61921&#msg_61921