### PR TITLE
WebSocket SNI fix for SSL connections

### DIFF
--- a/uppsrc/Core/Inet.h
+++ b/uppsrc/Core/Inet.h
@@ -715,6 +715,8 @@ class WebSocket {
 public:
 	WebSocket& NonBlocking(bool b = true)               { socket->Timeout(b ? 0 : Null); return *this; }
 
+	WebSocket&  SSLServerNameIndication(const String& name)   { socket->SSLServerNameIndication(name); return *this; }
+	
 	WebSocket&  Headers(const String& h)                { request_headers = h; return *this; }
 	WebSocket&  ClearHeaders()                          { return Headers(Null); }
 	WebSocket&  AddHeaders(const String& h)             { request_headers.Cat(h); return *this; }

--- a/uppsrc/Core/WebSocket.cpp
+++ b/uppsrc/Core/WebSocket.cpp
@@ -104,7 +104,7 @@ bool WebSocket::Connect(const String& uri_, const String& host_, bool ssl_, int 
 	uri = uri_;
 	host = host_;
 	ssl = ssl_;
-	
+
 	if(socket->IsBlocking()) {
 		if(!addrinfo.Execute(host, port)) {
 			Error("Not found");

--- a/uppsrc/Core/src.tpp/WebSocket_en-us.tpp
+++ b/uppsrc/Core/src.tpp/WebSocket_en-us.tpp
@@ -24,6 +24,13 @@ topic "WebSocket";
 is blocking mode.&]
 [s3;%% &]
 [s4; &]
+[s5;:Upp`:`:WebSocket`:`:SSLServerNameIndication`(const String`&`): WebSocket[@(0.0.255) `&
+] [* SSLServerNameIndication]([@(0.0.255) const] String[@(0.0.255) `&] 
+[*@3 name])&]
+[s2;%% Sets [^https`:`/`/cs`.wikipedia`.org`/wiki`/Server`_Name`_Indication^ SNI] 
+for SSL connection.&]
+[s3; &]
+[s4; &]
 [s5;:Upp`:`:WebSocket`:`:Headers`(const Upp`:`:String`&`): [_^Upp`:`:WebSocket^ WebSock
 et][@(0.0.255) `&]_[* Headers]([@(0.0.255) const]_[_^Upp`:`:String^ String][@(0.0.255) `&]_
 [*@3 h])&]


### PR DESCRIPTION
Currently, secure websocket connections will fail on many servers due to servers requiring SNI information and there is no way to add the info. 

This PR,

- Adds/exposes `SSLServerNameIndication` method to `WebSocket`.
- Updates the `WebSocket` docs.

Please review.