### PR TITLE
Fix recent warnings on macOS (April 2026)

### DIFF
--- a/uppsrc/Core/SSL/InitExit.cpp
+++ b/uppsrc/Core/SSL/InitExit.cpp
@@ -26,6 +26,7 @@ static void *SslAlloc(size_t size)
 }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+[[maybe_unused]]
 static void SslFree(void *ptr, const char *file, int line)
 #else
 static void SslFree(void *ptr)
@@ -44,6 +45,7 @@ static void SslFree(void *ptr)
 }
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
+[[maybe_unused]]
 static void *SslRealloc(void *ptr, size_t size, const char *file, int line)
 #else
 static void *SslRealloc(void *ptr, size_t size)

--- a/uppsrc/CtrlCore/CocoClip.mm
+++ b/uppsrc/CtrlCore/CocoClip.mm
@@ -513,8 +513,9 @@ int Ctrl::DoDragAndDrop(const char *fmts, const Image& sample, dword actions,
     CGImageRelease(cgimg);
     ReleaseCapture();
     
-    if(local_dnd_copy) // action was local and changed to copy in DragAndDrop
+    if(local_dnd_copy) { // action was local and changed to copy in DragAndDrop
         return DND_COPY;
+    }
     
 	return decode(src->result, NSDragOperationCopy, DND_COPY,
 	                           NSDragOperationMove, DND_MOVE,

--- a/uppsrc/CtrlCore/CocoProc.mm
+++ b/uppsrc/CtrlCore/CocoProc.mm
@@ -561,8 +561,9 @@ struct MMImp {
 - (void)setMarkedText:(id)aString selectedRange:(NSRange)selRange replacementRange:(NSRange)replacementRange
 {
 	Upp::GuiLock __;
-    if(![aString isKindOfClass:[NSAttributedString class]] )
+    if(![aString isKindOfClass:[NSAttributedString class]] ) {
         aString = [[[NSAttributedString alloc] initWithString:aString] autorelease];
+    }
 
 	Upp::MMImp::ShowPreedit(ctrl, Upp::ToWString([aString string]));
 }


### PR DESCRIPTION
The warnings are
```
/Users/klugier/Repos/upp/uppsrc/Core/SSL/InitExit.cpp (29): warning: unused function 'SslFree' [-Wunused-function]
 (): 29 | static void SslFree(void *ptr, const char *file, int line)
/Users/klugier/Repos/upp/uppsrc/Core/SSL/InitExit.cpp (47): warning: unused function 'SslRealloc' [-Wunused-function]
/Users/klugier/Repos/upp/uppsrc/CtrlCore/CocoClip.mm (519): warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
/Users/klugier/Repos/upp/uppsrc/CtrlCore/CocoProc.mm (567): warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
```
