### PR TITLE
umk: Fix crash with incomplete build methods

### DIFF
--- a/uppsrc/umk/umake.cpp
+++ b/uppsrc/umk/umake.cpp
@@ -57,7 +57,7 @@ VectorMap<String, String> Ide::GetMethodVars(const String& method)
 	const String method_dir = GetFileFolder(method);
 	const Vector<String> categories_with_method_dir = {"PATH", "INCLUDE", "LIB" };
 	for (const auto& category : categories_with_method_dir) {
-		map.GetAdd(category) = ReplaceMethodDir(map.Get(category), method_dir);
+		map.GetAdd(category) = ReplaceMethodDir(map.Get(category, String()), method_dir);
 	}
 
 	return map;


### PR DESCRIPTION
Fixes umk crash when build method file lacks at least "PATH", "INCLUDE", or "LIB" keys.

Motivation: In my nix dotfiles I have an `buildUppPackage` helper that generates the build method dynamically based on arguments, that did not generate .bm file with those keys by default, causing crashes on build failures on any package using it.

this crash didn't exist on v2025.1.1