### PR TITLE
Core: Add SIMD branchless, conditional packed/parallel increment function

### DIFF
--- a/uppsrc/Core/SIMD_NEON.h
+++ b/uppsrc/Core/SIMD_NEON.h
@@ -11,6 +11,8 @@ uint64 cmask16__(uint16x8_t mask) {
 
 const uint64 cmask_all__ = 0xffffffffffffffffull;
 
+struct i32x4; // Forward declaration for f32x4 -> i32x4 cast operator.
+
 struct f32x4 {
 	float32x4_t data;
 
@@ -35,6 +37,7 @@ struct f32x4 {
 	}
 	
 	operator float32x4_t()       { return data; }
+	explicit operator i32x4() const;
 };
 
 force_inline f32x4  f32all(double f) { return vdupq_n_f32((float)f); }
@@ -194,6 +197,10 @@ force_inline int    CountTrue(i32x4 a)              { return CountBits64(cmask32
 force_inline int    FirstTrue(i32x4 a)              { return CountTrailingZeroBits64(cmask32__(a.data)) >> 4; }
 force_inline int    FirstFalse(i32x4 a)             { return CountTrailingZeroBits64(~cmask32__(a.data)) >> 4; }
 force_inline bool   IsTrue(i32x4 a, int i)          { return cmask32__(a.data) & ((uint64)1 << (i << 4)); }
+
+force_inline f32x4::operator i32x4() const              { return i32x4(vreinterpretq_s32_f32(data)); }
+force_inline i32x4 IncrementIf(i32x4 value, i32x4 mask) { return value - mask; }
+force_inline i32x4 IncrementIf(i32x4 value, f32x4 mask) { return value - (i32x4) mask; }
 
 struct i8x16 { // 16*int8
 	int8x16_t data;

--- a/uppsrc/Core/SIMD_SSE2.h
+++ b/uppsrc/Core/SIMD_SSE2.h
@@ -1,3 +1,5 @@
+struct i32x4; // Forward declaration for f32x4 -> i32x4 cast operator.
+
 struct f32x4 {
 	__m128 data;
 
@@ -18,6 +20,7 @@ struct f32x4 {
 	f32x4(double a, double b, double c, double d) { data = _mm_set_ps((float)a, (float)b, (float)c, (float)d); }
 	
 	operator __m128()            { return data; }
+	explicit operator i32x4() const;
 };
 
 force_inline f32x4  f32all(double f)              { return _mm_set1_ps((float)f); }
@@ -150,6 +153,10 @@ force_inline int    CountTrue(i32x4 a)             { return CountBits(_mm_movema
 force_inline int    FirstTrue(i32x4 a)             { return CountTrailingZeroBits(_mm_movemask_ps(_mm_castsi128_ps(a.data))); }
 force_inline int    FirstFalse(i32x4 a)            { return CountTrailingZeroBits(~_mm_movemask_ps(_mm_castsi128_ps(a.data))); }
 force_inline bool   IsTrue(i32x4 a, int i)         { return _mm_movemask_ps(_mm_castsi128_ps(a.data)) & (1 << i); }
+
+force_inline f32x4::operator i32x4() const              { return i32x4(_mm_castps_si128(data)); }
+force_inline i32x4 IncrementIf(i32x4 value, i32x4 mask) { return value - mask; }
+force_inline i32x4 IncrementIf(i32x4 value, f32x4 mask) { return value - (i32x4) mask; }
 
 struct i8x16 : iTxN<i8x16> { // 16xint8
 	i8x16()                      {}


### PR DESCRIPTION
This PR adds the `IncrementIf` function for SIMD vectors, enabling branchless conditional increments of packed 32-bit integers (`i32x4`). The aim is to eliminate branch misprediction penalties for vector increments.

Can be used easily as such:

```cpp
	void DrawMandelbrotSIMD(ImageBuffer& img, Size sz) {
		RGBA* pix = img;
		float dx = (cx1 - cx0) / sz.cx;
		float dy = (cy1 - cy0) / sz.cy;
		const int block = 4;
		for(int py = 0; py < sz.cy; py++) {
			f32x4 cy4 = f32all(cy0 + py * dy);
			for(int px = 0; px < sz.cx; px += block) {
				float cx_vals[block];
				for(int i = 0; i < block; i++)
					cx_vals[i] = cx0 + (px + i) * dx;
				f32x4 cx4; cx4.Load(cx_vals);
				f32x4 zx = f32all(0.0f), zy = f32all(0.0f);
				i32x4 iter = i32all(0);
				for(int k = 0; k < maxiter; k++) {
					f32x4 zx2  = zx * zx;
					f32x4 zy2  = zy * zy;
					f32x4 mag2 = zx2 + zy2;
					f32x4 mask = mag2 < f32all(4.0f);
					if(!AnyTrue(mask))
						break;
					f32x4 zxy = zx * zy;
					zx   = zx2 - zy2 + cx4;
					zy   = zxy + zxy + cy4;
					iter = IncrementIf(iter, mask);
				}
				alignas(16) int tmp[block];
				iter.Store(tmp);
				for(int i = 0; i < block; i++) {
					if(px + i >= sz.cx)
                        break;
					float hue = 360.0f * tmp[i] / maxIter;
					RGBA c = HSVtoRGB(hue, 1.0f, tmp[i] < maxIter ? 1.0f : 0.0f);
					pix[py * sz.cx + px + i] = c;
				}
			}
		}
	}
```